### PR TITLE
feat: Added ERC20Deployed events

### DIFF
--- a/orchestrator/eth_event_watcher.go
+++ b/orchestrator/eth_event_watcher.go
@@ -55,6 +55,39 @@ func (s *peggyOrchestrator) CheckForEvents(
 		return 0, err
 	}
 
+	var erc20DeployedEvents []*wrappers.PeggyERC20DeployedEvent
+	{
+		iter, err := peggyFilterer.FilterERC20DeployedEvent(&bind.FilterOpts{
+			Start: startingBlock,
+			End:   &currentBlock,
+		}, nil)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"start": startingBlock,
+				"end":   currentBlock,
+			}).Errorln("failed to scan past ERC20Deployed events from Ethereum")
+
+			if !isUnknownBlockErr(err) {
+				err = errors.Wrap(err, "failed to scan past ERC20Deployed events from Ethereum")
+				return 0, err
+			} else if iter == nil {
+				return 0, errors.New("no iterator returned")
+			}
+		}
+
+		for iter.Next() {
+			erc20DeployedEvents = append(erc20DeployedEvents, iter.Event)
+		}
+
+		iter.Close()
+	}
+
+	log.WithFields(log.Fields{
+		"start":     startingBlock,
+		"end":       currentBlock,
+		"Contracts": erc20DeployedEvents,
+	}).Debugln("Scanned ERC20Deployed events from Ethereum")
+
 	var sendToCosmosEvents []*wrappers.PeggySendToCosmosEvent
 	{
 
@@ -168,10 +201,12 @@ func (s *peggyOrchestrator) CheckForEvents(
 	deposits := filterSendToCosmosEventsByNonce(sendToCosmosEvents, lastClaimEvent.EthereumEventNonce)
 	withdraws := filterTransactionBatchExecutedEventsByNonce(transactionBatchExecutedEvents, lastClaimEvent.EthereumEventNonce)
 	valsetUpdates := filterValsetUpdateEventsByNonce(valsetUpdatedEvents, lastClaimEvent.EthereumEventNonce)
+	deployedERC20Updates := filterERC20DeployedEventsByNonce(erc20DeployedEvents, lastClaimEvent.EthereumEventNonce)
 
-	if len(deposits) > 0 || len(withdraws) > 0 || len(valsetUpdates) > 0 {
+	if len(deposits) > 0 || len(withdraws) > 0 || len(valsetUpdates) > 0 || len(deployedERC20Updates) > 0 {
 		// todo get eth chain id from the chain
-		if err := s.peggyBroadcastClient.SendEthereumClaims(ctx, lastClaimEvent.EthereumEventNonce, deposits, withdraws, valsetUpdates); err != nil {
+		if err := s.peggyBroadcastClient.SendEthereumClaims(ctx, lastClaimEvent.EthereumEventNonce, deposits, withdraws, valsetUpdates, deployedERC20Updates); err != nil {
+
 			err = errors.Wrap(err, "failed to send ethereum claims to Cosmos chain")
 			return 0, err
 		}
@@ -215,6 +250,20 @@ func filterValsetUpdateEventsByNonce(
 	nonce uint64,
 ) []*wrappers.PeggyValsetUpdatedEvent {
 	res := make([]*wrappers.PeggyValsetUpdatedEvent, 0, len(events))
+
+	for _, ev := range events {
+		if ev.EventNonce.Uint64() > nonce {
+			res = append(res, ev)
+		}
+	}
+	return res
+}
+
+func filterERC20DeployedEventsByNonce(
+	events []*wrappers.PeggyERC20DeployedEvent,
+	nonce uint64,
+) []*wrappers.PeggyERC20DeployedEvent {
+	res := make([]*wrappers.PeggyERC20DeployedEvent, 0, len(events))
 
 	for _, ev := range events {
 		if ev.EventNonce.Uint64() > nonce {

--- a/test/cosmos/multinode.sh
+++ b/test/cosmos/multinode.sh
@@ -146,6 +146,11 @@ if [[ ! -d "$hdir" ]]; then
 		cat $n0cfgDir/genesis.json | jq '.app_state["crisis"]["constant_fee"]["denom"]="'$DENOM'"' > $n0cfgDir/tmp_genesis.json && mv $n0cfgDir/tmp_genesis.json $n0cfgDir/genesis.json
 		cat $n0cfgDir/genesis.json | jq '.app_state["gov"]["deposit_params"]["min_deposit"][0]["denom"]="'$DENOM'"' > $n0cfgDir/tmp_genesis.json && mv $n0cfgDir/tmp_genesis.json $n0cfgDir/genesis.json
 		cat $n0cfgDir/genesis.json | jq '.app_state["mint"]["params"]["mint_denom"]="'$DENOM'"' > $n0cfgDir/tmp_genesis.json && mv $n0cfgDir/tmp_genesis.json $n0cfgDir/genesis.json
+		cat $n0cfgDir/genesis.json | jq '.consensus_params["block"]["time_iota_ms]="5000"' > $n0cfgDir/tmp_genesis.json && mv $n0cfgDir/tmp_genesis.json $n0cfgDir/genesis.json
+		cat $n0cfgDir/genesis.json | jq '.app_state["peggy"]["params"]["bridge_ethereum_address"]="0x93b5122922F9dCd5458Af42Ba69Bd7baEc546B3c"' > $n0cfgDir/tmp_genesis.json && mv $n0cfgDir/tmp_genesis.json $n0cfgDir/genesis.json
+		cat $n0cfgDir/genesis.json | jq '.app_state["peggy"]["params"]["bridge_chain_id"]="5"' > $n0cfgDir/tmp_genesis.json && mv $n0cfgDir/tmp_genesis.json $n0cfgDir/genesis.json
+		cat $n0cfgDir/genesis.json | jq '.app_state["peggy"]["params"]["bridge_contract_start_height"]="5763150"' > $n0cfgDir/tmp_genesis.json && mv $n0cfgDir/tmp_genesis.json $n0cfgDir/genesis.json
+		cat $n0cfgDir/genesis.json | jq '.app_state["peggy"]["params"]["cosmos_coin_denom"]=""' > $n0cfgDir/tmp_genesis.json && mv $n0cfgDir/tmp_genesis.json $n0cfgDir/genesis.json
 	fi
 
 	echo "NOTE: Setting Governance Voting Period to 10 seconds for rapid testing"


### PR DESCRIPTION
**Context**
Peggo wasn't realying the ERC20DeployedEvent messages (fired by the Peggy contract when executing deployERC20) to umee. As a consequence, Umee wasn't getting notified about the correlation of the ERC20 addresses and native coins, so when trying to send uumee from Umee to Eth, it would default to a nil address and fail to relay the coins.

**Fix**
Copied what peggo was doing for other events so now it also relays ERC20DeployedEvents.

**Notes**
Do not populate `cosmos_coin_denom` or `cosmos_coin_erc20_contract` in the genesis.
