### PR TITLE
refactor: query for ERC20 mapping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/tendermint/tendermint v0.34.14
 	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
-	github.com/umee-network/umee v0.0.0-20211023233917-5816260c0998
+	github.com/umee-network/umee v0.4.0-rc2
 	github.com/xlab/closer v0.0.0-20190328110542-03326addb7c2 // indirect
 	github.com/xlab/suplog v1.3.1
 	go.etcd.io/bbolt v1.3.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1841,6 +1841,8 @@ github.com/ultraware/whitespace v0.0.4 h1:If7Va4cM03mpgrNH9k49/VOicWpGoG70XPBFFO
 github.com/ultraware/whitespace v0.0.4/go.mod h1:aVMh/gQve5Maj9hQ/hg+F75lr/X5A89uZnzAmWSineA=
 github.com/umee-network/umee v0.0.0-20211023233917-5816260c0998 h1:JOF0E98XmW0p79x8B11UPgczJpxXpQkLYmqsVFCEyxA=
 github.com/umee-network/umee v0.0.0-20211023233917-5816260c0998/go.mod h1:raBxumGtRPUPS5X4+li1icy+pndNMvKSRuy9PAW4dgU=
+github.com/umee-network/umee v0.4.0-rc2 h1:s8l0foZFyiOW35nU4z+0HHyYxqJDBY3s8+THnN8Hj2Q=
+github.com/umee-network/umee v0.4.0-rc2/go.mod h1:vNHHRrKD27tHpzHsSuKXy8tbh2v3l0iVyYzDCm73anU=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=

--- a/orchestrator/cosmos/query.go
+++ b/orchestrator/cosmos/query.go
@@ -18,11 +18,10 @@ type PeggyQueryClient interface {
 	OldestUnsignedTransactionBatch(ctx context.Context, valAccountAddress sdk.AccAddress) (*types.OutgoingTxBatch, error)
 	LatestTransactionBatches(ctx context.Context) ([]*types.OutgoingTxBatch, error)
 	UnbatchedTokensWithFees(ctx context.Context) ([]*types.BatchFees, error)
-
 	TransactionBatchSignatures(ctx context.Context, nonce uint64, tokenContract ethcmn.Address) ([]*types.MsgConfirmBatch, error)
 	LastClaimEventByAddr(ctx context.Context, validatorAccountAddress sdk.AccAddress) (*types.LastClaimEvent, error)
-
 	PeggyParams(ctx context.Context) (*types.Params, error)
+	ERC20ToDenom(ctx context.Context, contractAddr ethcmn.Address) (*types.QueryDenomToERC20Response, error)
 }
 
 func NewPeggyQueryClient(client types.QueryClient) PeggyQueryClient {

--- a/orchestrator/cosmos/query.go
+++ b/orchestrator/cosmos/query.go
@@ -21,7 +21,7 @@ type PeggyQueryClient interface {
 	TransactionBatchSignatures(ctx context.Context, nonce uint64, tokenContract ethcmn.Address) ([]*types.MsgConfirmBatch, error)
 	LastClaimEventByAddr(ctx context.Context, validatorAccountAddress sdk.AccAddress) (*types.LastClaimEvent, error)
 	PeggyParams(ctx context.Context) (*types.Params, error)
-	ERC20ToDenom(ctx context.Context, contractAddr ethcmn.Address) (*types.QueryDenomToERC20Response, error)
+	ERC20ToDenom(ctx context.Context, contractAddr ethcmn.Address) (*types.QueryERC20ToDenomResponse, error)
 }
 
 func NewPeggyQueryClient(client types.QueryClient) PeggyQueryClient {
@@ -179,4 +179,17 @@ func (s *peggyQueryClient) PeggyParams(ctx context.Context) (*types.Params, erro
 	}
 
 	return &daemonResp.Params, nil
+}
+
+func (s *peggyQueryClient) ERC20ToDenom(ctx context.Context, contractAddr ethcmn.Address) (*types.QueryERC20ToDenomResponse, error) {
+	daemonResp, err := s.daemonQueryClient.ERC20ToDenom(ctx, &types.QueryERC20ToDenomRequest{
+		Erc20: contractAddr.Hex(),
+	})
+	if err != nil {
+		err = errors.Wrap(err, "failed to query ERC20ToDenom from daemon")
+		return nil, err
+	} else if daemonResp == nil {
+		return nil, ErrNotFound
+	}
+	return daemonResp, nil
 }

--- a/orchestrator/main_loops.go
+++ b/orchestrator/main_loops.go
@@ -298,20 +298,15 @@ func (s *peggyOrchestrator) BatchRequesterLoop(ctx context.Context) (err error) 
 						// request with cosmosDenom.
 						tokenAddr := ethcmn.HexToAddress(unbatchedToken.Token)
 
+						var denom string
 						resp, err := s.cosmosQueryClient.ERC20ToDenom(ctx, tokenAddr)
 						if err != nil {
-							return err
+							logger.Err(err).Str("token_contract", tokenAddr.String()).Msg("failed to get denom, won't request for a batch")
+							// do not return error, just continue with the next unbatched tx.
+							return nil
 						}
 
-						// TODO: Use cosmosQueryClient to query for on-chain mapping.
-						// var denom string
-						// if cosmosDenom, ok := s.erc20ContractMapping[tokenAddr]; ok {
-						// 	// cosmos denom
-						// 	denom = cosmosDenom
-						// } else {
-						// 	// peggy denom
-						// 	denom = types.PeggyDenomString(tokenAddr)
-						// }
+						denom = resp.GetDenom()
 
 						// send batch request only if fee threshold is met
 						if s.CheckFeeThreshold(tokenAddr, unbatchedToken.TotalFees, s.minBatchFeeUSD) {

--- a/orchestrator/main_loops.go
+++ b/orchestrator/main_loops.go
@@ -307,9 +307,9 @@ func (s *peggyOrchestrator) BatchRequesterLoop(ctx context.Context) (err error) 
 							denom = types.PeggyDenomString(tokenAddr)
 						}
 
-						// send batch request only if fee threshold is met.
+						// send batch request only if fee threshold is met
 						if s.CheckFeeThreshold(tokenAddr, unbatchedToken.TotalFees, s.minBatchFeeUSD) {
-							logger.WithFields(log.Fields{"tokenContract": tokenAddr, "denom": denom}).Infoln("sending batch request")
+							logger.Info().Str("token_contract", tokenAddr.String()).Str("denom", denom).Msg("sending batch request")
 							_ = s.peggyBroadcastClient.SendRequestBatch(ctx, denom)
 						}
 

--- a/orchestrator/main_loops.go
+++ b/orchestrator/main_loops.go
@@ -298,6 +298,11 @@ func (s *peggyOrchestrator) BatchRequesterLoop(ctx context.Context) (err error) 
 						// request with cosmosDenom.
 						tokenAddr := ethcmn.HexToAddress(unbatchedToken.Token)
 
+						resp, err := s.cosmosQueryClient.ERC20ToDenom(ctx, tokenAddr)
+						if err != nil {
+							return err
+						}
+
 						// TODO: Use cosmosQueryClient to query for on-chain mapping.
 						// var denom string
 						// if cosmosDenom, ok := s.erc20ContractMapping[tokenAddr]; ok {

--- a/orchestrator/main_loops.go
+++ b/orchestrator/main_loops.go
@@ -298,14 +298,15 @@ func (s *peggyOrchestrator) BatchRequesterLoop(ctx context.Context) (err error) 
 						// request with cosmosDenom.
 						tokenAddr := ethcmn.HexToAddress(unbatchedToken.Token)
 
-						var denom string
-						if cosmosDenom, ok := s.erc20ContractMapping[tokenAddr]; ok {
-							// cosmos denom
-							denom = cosmosDenom
-						} else {
-							// peggy denom
-							denom = types.PeggyDenomString(tokenAddr)
-						}
+						// TODO: Use cosmosQueryClient to query for on-chain mapping.
+						// var denom string
+						// if cosmosDenom, ok := s.erc20ContractMapping[tokenAddr]; ok {
+						// 	// cosmos denom
+						// 	denom = cosmosDenom
+						// } else {
+						// 	// peggy denom
+						// 	denom = types.PeggyDenomString(tokenAddr)
+						// }
 
 						// send batch request only if fee threshold is met
 						if s.CheckFeeThreshold(tokenAddr, unbatchedToken.TotalFees, s.minBatchFeeUSD) {

--- a/orchestrator/options.go
+++ b/orchestrator/options.go
@@ -1,7 +1,6 @@
 package orchestrator
 
 import (
-	ethcmn "github.com/ethereum/go-ethereum/common"
 	"github.com/umee-network/peggo/orchestrator/coingecko"
 )
 
@@ -12,16 +11,6 @@ func SetMinBatchFee(minFee float64) func(PeggyOrchestrator) {
 
 func (p *peggyOrchestrator) SetMinBatchFee(minFee float64) {
 	p.minBatchFeeUSD = minFee
-}
-
-// SetERC20ContractMapping sets the (optional) ERC20 contract mapping Cosmos
-// native token denominations to their ERC20 contract addresses.
-func SetERC20ContractMapping(m map[ethcmn.Address]string) func(PeggyOrchestrator) {
-	return func(p PeggyOrchestrator) { p.SetERC20ContractMapping(m) }
-}
-
-func (p *peggyOrchestrator) SetERC20ContractMapping(m map[ethcmn.Address]string) {
-	p.erc20ContractMapping = m
 }
 
 // SetPriceFeeder sets the (optional) price feeder used when performing profitable

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -26,7 +26,6 @@ type PeggyOrchestrator interface {
 	RelayerMainLoop(ctx context.Context) error
 
 	SetMinBatchFee(float64)
-	SetERC20ContractMapping(map[ethcmn.Address]string)
 	SetPriceFeeder(*coingecko.CoingeckoPriceFeed)
 }
 
@@ -43,9 +42,8 @@ type peggyOrchestrator struct {
 	relayer              relayer.PeggyRelayer
 
 	// optional inputs with defaults
-	erc20ContractMapping map[ethcmn.Address]string
-	minBatchFeeUSD       float64
-	priceFeeder          *coingecko.CoingeckoPriceFeed
+	minBatchFeeUSD float64
+	priceFeeder    *coingecko.CoingeckoPriceFeed
 }
 
 func NewPeggyOrchestrator(
@@ -63,7 +61,7 @@ func NewPeggyOrchestrator(
 
 	var orch PeggyOrchestrator
 	orch = &peggyOrchestrator{
-		logger:               logger,
+		logger:               logger.With().Str("module", "orchestrator").Logger(),
 		tmClient:             tmClient,
 		cosmosQueryClient:    cosmosQueryClient,
 		peggyBroadcastClient: peggyBroadcastClient,


### PR DESCRIPTION
Instead of using a hard-coded user-provided ERC20 denom to contract mapping, we fetch the mapping from the chain on each request.
