### PR TITLE
Re-add hashing test

### DIFF
--- a/solidity/contracts/HashingTest.sol
+++ b/solidity/contracts/HashingTest.sol
@@ -9,67 +9,30 @@ contract HashingTest {
 	uint256[] public state_powers;
 	uint256 public state_nonce;
 
-	function IterativeHash(
+	// CheckpointHash copies how makeCheckpoint in Peggy.sol works
+	function CheckpointHash(
 		address[] memory _validators,
 		uint256[] memory _powers,
 		uint256 _valsetNonce,
+		uint256 _rewardAmount,
+		address _rewardToken,
 		bytes32 _peggyId
 	) public {
 		// bytes32 encoding of the string "checkpoint"
 		bytes32 methodName = 0x636865636b706f696e7400000000000000000000000000000000000000000000;
 
-		bytes32 checkpoint = keccak256(abi.encode(_peggyId, methodName, _valsetNonce));
-
-		// Iterative hashing of valset
-		{
-			for (uint256 i = 0; i < _validators.length; i = i + 1) {
-				// Check that validator powers are decreasing or equal (this allows the next
-				// caller to break out of signature evaluation ASAP to save more gas)
-				if (i != 0) {
-					require(
-						!(_powers[i] > _powers[i - 1]),
-						"Validator power must not be higher than previous validator in batch"
-					);
-				}
-				checkpoint = keccak256(abi.encode(checkpoint, _validators[i], _powers[i]));
-			}
-		}
-
-		lastCheckpoint = checkpoint;
-	}
-
-	function ConcatHash(
-		address[] memory _validators,
-		uint256[] memory _powers,
-		uint256 _valsetNonce,
-		bytes32 _peggyId
-	) public {
-		// bytes32 encoding of the string "checkpoint"
-		bytes32 methodName = 0x636865636b706f696e7400000000000000000000000000000000000000000000;
-
-		bytes32 idHash = keccak256(abi.encode(_peggyId, methodName, _valsetNonce));
-
-		bytes32 validatorHash = keccak256(abi.encode(_validators));
-
-		bytes32 powersHash = keccak256(abi.encode(_powers));
-
-		bytes32 checkpoint = keccak256(abi.encode(idHash, validatorHash, powersHash));
-
-		lastCheckpoint = checkpoint;
-	}
-
-	function ConcatHash2(
-		address[] memory _validators,
-		uint256[] memory _powers,
-		uint256 _valsetNonce,
-		bytes32 _peggyId
-	) public {
-		// bytes32 encoding of the string "checkpoint"
-		bytes32 methodName = 0x636865636b706f696e7400000000000000000000000000000000000000000000;
-
-		bytes32 checkpoint = keccak256(
-			abi.encode(_peggyId, methodName, _valsetNonce, _validators, _powers)
-		);
+		bytes32 checkpoint =
+			keccak256(
+				abi.encode(
+				_peggyId,
+				methodName,
+				_valsetNonce,
+				_validators,
+				_powers,
+				_rewardAmount,
+				_rewardToken
+				)
+			);
 
 		lastCheckpoint = checkpoint;
 	}

--- a/test/peggo/hashing_test.go
+++ b/test/peggo/hashing_test.go
@@ -1,155 +1,143 @@
 package solidity
 
 import (
+	"context"
 	"math/big"
 	"strings"
 
+	"github.com/InjectiveLabs/etherman/deployer"
+	"github.com/InjectiveLabs/etherman/sol"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 
-	// . "github.com/onsi/ginkgo"
-	// . "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 
 	"github.com/umee-network/peggo/orchestrator/ethereum/peggy"
 )
 
-// TODO: fix and re-add test
-// var _ = Describe("Contract Tests", func() {
-// 	_ = Describe("Hashing Test", func() {
-// 		var (
-// 			hashingTestTxOpts   deployer.ContractTxOpts
-// 			hashingTestCallOpts deployer.ContractCallOpts
-// 			hashingTestContract *sol.Contract
-// 			deployErr           error
-// 		)
+var _ = Describe("Contract Tests", func() {
+	_ = Describe("Hashing Test", func() {
+		var (
+			hashingTestTxOpts   deployer.ContractTxOpts
+			hashingTestCallOpts deployer.ContractCallOpts
+			hashingTestContract *sol.Contract
+			deployErr           error
+		)
 
-// 		JustBeforeEach(func() {
-// 			if hashingTestContract != nil {
-// 				return
-// 			}
+		JustBeforeEach(func() {
+			if hashingTestContract != nil {
+				return
+			}
 
-// 			hashingTestDeployOpts := deployer.ContractDeployOpts{
-// 				From:          EthAccounts[0].EthAddress,
-// 				FromPk:        EthAccounts[0].EthPrivKey,
-// 				SolSource:     "../../solidity/contracts/HashingTest.sol",
-// 				ContractName:  "HashingTest",
-// 				Await:         true,
-// 				CoverageAgent: CoverageAgent,
-// 			}
+			hashingTestDeployOpts := deployer.ContractDeployOpts{
+				From:          EthAccounts[0].EthAddress,
+				FromPk:        EthAccounts[0].EthPrivKey,
+				SolSource:     "../../solidity/contracts/HashingTest.sol",
+				ContractName:  "HashingTest",
+				Await:         true,
+				CoverageAgent: CoverageAgent,
+			}
 
-// 			_, hashingTestContract, deployErr = ContractDeployer.Deploy(context.Background(), hashingTestDeployOpts, noArgs)
-// 		})
+			_, hashingTestContract, deployErr = ContractDeployer.Deploy(context.Background(), hashingTestDeployOpts, noArgs)
+		})
 
-// 		_ = It("Deploys HashingTest.sol", func() {
-// 			Ω(deployErr).Should(BeNil())
-// 			Ω(hashingTestContract).ShouldNot(BeNil())
-// 			Ω(hashingTestContract.Address).ShouldNot(Equal(zeroAddress))
-// 		})
+		_ = It("Deploys HashingTest.sol", func() {
+			Ω(deployErr).Should(BeNil())
+			Ω(hashingTestContract).ShouldNot(BeNil())
+			Ω(hashingTestContract.Address).ShouldNot(Equal(zeroAddress))
+		})
 
-// 		_ = Context("HashingTest contract deployment done", func() {
-// 			var (
-// 				peggyID     common.Hash
-// 				validators  []common.Address
-// 				powers      []*big.Int
-// 				valsetNonce *big.Int
-// 			)
+		_ = Context("HashingTest contract deployment done", func() {
+			var (
+				peggyID     common.Hash
+				validators  []common.Address
+				powers      []*big.Int
+				valsetNonce *big.Int
+			)
 
-// 			BeforeEach(func() {
-// 				orFail(deployErr)
+			BeforeEach(func() {
+				orFail(deployErr)
 
-// 				hashingTestTxOpts = deployer.ContractTxOpts{
-// 					From:          EthAccounts[0].EthAddress,
-// 					FromPk:        EthAccounts[0].EthPrivKey,
-// 					SolSource:     "../../solidity/contracts/HashingTest.sol",
-// 					ContractName:  "HashingTest",
-// 					Contract:      hashingTestContract.Address,
-// 					Await:         true,
-// 					CoverageAgent: CoverageAgent,
-// 				}
+				hashingTestTxOpts = deployer.ContractTxOpts{
+					From:          EthAccounts[0].EthAddress,
+					FromPk:        EthAccounts[0].EthPrivKey,
+					SolSource:     "../../solidity/contracts/HashingTest.sol",
+					ContractName:  "HashingTest",
+					Contract:      hashingTestContract.Address,
+					Await:         true,
+					CoverageAgent: CoverageAgent,
+				}
 
-// 				hashingTestCallOpts = deployer.ContractCallOpts{
-// 					From:          EthAccounts[0].EthAddress,
-// 					SolSource:     "../../solidity/contracts/HashingTest.sol",
-// 					ContractName:  "HashingTest",
-// 					Contract:      hashingTestContract.Address,
-// 					CoverageAgent: CoverageAgent,
-// 					CoverageCall: deployer.ContractCoverageCallOpts{
-// 						FromPk: EthAccounts[0].EthPrivKey,
-// 					},
-// 				}
-// 			})
+				hashingTestCallOpts = deployer.ContractCallOpts{
+					From:          EthAccounts[0].EthAddress,
+					SolSource:     "../../solidity/contracts/HashingTest.sol",
+					ContractName:  "HashingTest",
+					Contract:      hashingTestContract.Address,
+					CoverageAgent: CoverageAgent,
+					CoverageCall: deployer.ContractCoverageCallOpts{
+						FromPk: EthAccounts[0].EthPrivKey,
+					},
+				}
+			})
 
-// 			BeforeEach(func() {
-// 				peggyID = formatBytes32String("foo")
-// 				validators = getEthAddresses(CosmosAccounts[:3]...)
-// 				powers = make([]*big.Int, len(validators))
-// 				for i := range powers {
-// 					powers[i] = big.NewInt(5000)
-// 				}
+			BeforeEach(func() {
+				peggyID = formatBytes32String("foo")
+				validators = getEthAddresses(CosmosAccounts[:3]...)
+				powers = make([]*big.Int, len(validators))
+				for i := range powers {
+					powers[i] = big.NewInt(5000)
+				}
 
-// 				valsetNonce = big.NewInt(1)
-// 			})
+				valsetNonce = big.NewInt(1)
+			})
 
-// 			It("Should have address", func() {
-// 				Ω(hashingTestTxOpts.Contract).ShouldNot(Equal(zeroAddress))
-// 				Ω(hashingTestCallOpts.Contract).ShouldNot(Equal(zeroAddress))
-// 			})
+			It("Should have address", func() {
+				Ω(hashingTestTxOpts.Contract).ShouldNot(Equal(zeroAddress))
+				Ω(hashingTestCallOpts.Contract).ShouldNot(Equal(zeroAddress))
+			})
 
-// 			It("Update checkpoint using IterativeHash", func() {
-// 				_, _, err := ContractDeployer.Tx(context.Background(), hashingTestTxOpts,
-// 					"IterativeHash", withArgsFn(validators, powers, valsetNonce, peggyID),
-// 				)
-// 				Ω(err).Should(BeNil())
-// 			})
+			It("Update checkpoint using CheckpointHash", func() {
+				_, _, err := ContractDeployer.Tx(context.Background(), hashingTestTxOpts,
+					"CheckpointHash", withArgsFn(validators, powers, valsetNonce, big.NewInt(0), zeroAddress, peggyID),
+				)
+				Ω(err).Should(BeNil())
+			})
 
-// 			It("Update checkpoint using ConcatHash", func() {
-// 				_, _, err := ContractDeployer.Tx(context.Background(), hashingTestTxOpts,
-// 					"ConcatHash", withArgsFn(validators, powers, valsetNonce, peggyID),
-// 				)
-// 				Ω(err).Should(BeNil())
-// 			})
+			It("Ensure that checkpoint equals the off-chain version", func() {
+				var lastCheckpoint common.Hash
 
-// 			It("Update checkpoint using ConcatHash2", func() {
-// 				_, _, err := ContractDeployer.Tx(context.Background(), hashingTestTxOpts,
-// 					"ConcatHash2", withArgsFn(validators, powers, valsetNonce, peggyID),
-// 				)
-// 				Ω(err).Should(BeNil())
-// 			})
+				out, outAbi, err := ContractDeployer.Call(context.Background(), hashingTestCallOpts,
+					"lastCheckpoint", noArgs,
+				)
+				Ω(err).Should(BeNil())
 
-// 			It("Ensure that checkpoint equals the off-chain version", func() {
-// 				var lastCheckpoint common.Hash
+				err = outAbi.Copy(&lastCheckpoint, out)
+				Ω(err).Should(BeNil())
 
-// 				out, outAbi, err := ContractDeployer.Call(context.Background(), hashingTestCallOpts,
-// 					"lastCheckpoint", noArgs,
-// 				)
-// 				Ω(err).Should(BeNil())
+				Ω(lastCheckpoint).ShouldNot(Equal(zeroHash))
+				Ω(lastCheckpoint).Should(Equal(
+					makeValsetCheckpoint(peggyID, validators, powers, valsetNonce, big.NewInt(0), zeroAddress),
+				))
+			})
 
-// 				err = outAbi.Copy(&lastCheckpoint, out)
-// 				Ω(err).Should(BeNil())
+			It("Saves everything", func() {
+				_, _, err := ContractDeployer.Tx(context.Background(), hashingTestTxOpts,
+					"JustSaveEverything", withArgsFn(validators, powers, valsetNonce),
+				)
+				Ω(err).Should(BeNil())
+			})
 
-// 				Ω(lastCheckpoint).ShouldNot(Equal(zeroHash))
-// 				Ω(lastCheckpoint).Should(Equal(
-// 					makeValsetCheckpoint(peggyID, validators, powers, valsetNonce),
-// 				))
-// 			})
-
-// 			It("Saves everything", func() {
-// 				_, _, err := ContractDeployer.Tx(context.Background(), hashingTestTxOpts,
-// 					"JustSaveEverything", withArgsFn(validators, powers, valsetNonce),
-// 				)
-// 				Ω(err).Should(BeNil())
-// 			})
-
-// 			It("Saves everything again", func() {
-// 				_, _, err := ContractDeployer.Tx(context.Background(), hashingTestTxOpts,
-// 					"JustSaveEverythingAgain", withArgsFn(validators, powers, valsetNonce),
-// 				)
-// 				Ω(err).Should(BeNil())
-// 			})
-// 		})
-// 	})
-// })
+			It("Saves everything again", func() {
+				_, _, err := ContractDeployer.Tx(context.Background(), hashingTestTxOpts,
+					"JustSaveEverythingAgain", withArgsFn(validators, powers, valsetNonce),
+				)
+				Ω(err).Should(BeNil())
+			})
+		})
+	})
+})
 
 var valsetConfirmABI, _ = abi.JSON(strings.NewReader(peggy.ValsetCheckpointABIJSON))
 
@@ -158,13 +146,21 @@ func makeValsetCheckpoint(
 	validators []common.Address,
 	powers []*big.Int,
 	valsetNonce *big.Int,
+	rewardAmount *big.Int,
+	rewardToken common.Address,
 ) common.Hash {
 	methodName := formatBytes32String("checkpoint")
 
 	//TODO: check if we want to add a reward amount and a reward token here
 
 	buf, err := valsetConfirmABI.Pack("checkpoint",
-		peggyID, methodName, valsetNonce, validators, powers, &big.Int{}, zeroAddress,
+		peggyID,
+		methodName,
+		valsetNonce,
+		validators,
+		powers,
+		rewardAmount,
+		rewardToken,
 	)
 
 	orFail(err)

--- a/test/peggo/peggy_contract_test.go
+++ b/test/peggo/peggy_contract_test.go
@@ -211,7 +211,7 @@ var _ = Describe("Contract Tests", func() {
 					)
 					Ω(err).Should(BeNil())
 
-					offchainCheckpoint := makeValsetCheckpoint(peggyID, validators, powers, big.NewInt(0))
+					offchainCheckpoint := makeValsetCheckpoint(peggyID, validators, powers, big.NewInt(0), big.NewInt(0), zeroAddress)
 
 					err = outAbi.Copy(&state_lastValsetCheckpoint, out)
 					Ω(err).Should(BeNil())
@@ -296,6 +296,8 @@ var _ = Describe("Contract Tests", func() {
 							newValidators,
 							newPowers,
 							nextValsetNonce,
+							big.NewInt(0),
+							zeroAddress,
 						)
 
 						sigsV, sigsR, sigsS, signValsetErr = signDigest(
@@ -421,6 +423,8 @@ var _ = Describe("Contract Tests", func() {
 							validators,
 							powers,
 							nextValsetNonce,
+							big.NewInt(0),
+							zeroAddress,
 						)
 
 						sigsV, sigsR, sigsS, signValsetErr = signDigest(


### PR DESCRIPTION
This test was partially re-written to comply with what Peggy is doing. Seems like the main goal of this test is to ensure that we have a validated way of creating checkpoint hashes in Go.

Closes #13 