### PR TITLE
chore: Remove CLI command to register Ethereum key

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,16 @@ sign claims going from Ethereum to Umee and to sign any transactions sent to
 Ethereum (batches or validator set updates).
 
 ```shell
-$ peggo tx register-eth-key \
-  --cosmos-chain-id="..." \
-  --cosmos-grpc="tcp://..." \
-  --tendermint-rpc="http://..." \
-  --cosmos-keyring=... \
-  --cosmos-keyring-dir=... \
-  --cosmos-from=... \
-  --eth-pk=$ETH_PK
+$ umeed tx peggy set-orchestrator-address \
+  {validatorAddress} \
+  {validatorAddress} \
+  {ethAddress} \
+  --eth-priv-key="..." \
+  --chain-id="..." \
+  --fees="..." \
+  --keyring-backend=... \
+  --keyring-dir=... \
+  --from=...
 ```
 
 ### Run the orchestrator
@@ -61,7 +63,6 @@ $ peggo orchestrator \
   --eth-rpc=$ETH_RPC \
   --relay-batches=true \
   --relay-valsets=true \
-  --eth-chain-id=... \
   --cosmos-chain-id=... \
   --cosmos-grpc="tcp://..." \
   --tendermint-rpc="http://..." \

--- a/cmd/peggo/flags.go
+++ b/cmd/peggo/flags.go
@@ -13,7 +13,6 @@ const (
 	flagLogLevel                = "log-level"
 	flagLogFormat               = "log-format"
 	flagSvcWaitTimeout          = "svc-wait-timeout"
-	flagAutoConfirm             = "yes"
 	flagCosmosChainID           = "cosmos-chain-id"
 	flagCosmosGRPC              = "cosmos-grpc"
 	flagTendermintRPC           = "tendermint-rpc"

--- a/cmd/peggo/tx.go
+++ b/cmd/peggo/tx.go
@@ -1,17 +1,7 @@
 package peggo
 
 import (
-	"context"
-	"fmt"
-	"os"
-	"time"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cobra"
-	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
-	"github.com/umee-network/peggo/cmd/peggo/client"
-	"github.com/umee-network/peggo/orchestrator/cosmos"
-	peggytypes "github.com/umee-network/umee/x/peggy/types"
 )
 
 func getTxCmd() *cobra.Command {
@@ -19,115 +9,6 @@ func getTxCmd() *cobra.Command {
 		Use:   "tx",
 		Short: "Transactions for Peggy (Gravity Bridge) governance and maintenance on the Cosmos chain",
 	}
-
-	cmd.AddCommand(
-		getRegisterEthKeyCmd(),
-	)
-
-	return cmd
-}
-
-func getRegisterEthKeyCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "register-eth-key",
-		Short: "Submits an Ethereum key that will be used to sign messages on behalf of your Validator",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			konfig, err := parseServerConfig(cmd)
-			if err != nil {
-				return err
-			}
-
-			if konfig.Bool(flagEthUseLedger) {
-				fmt.Fprintln(
-					os.Stderr,
-					"WARNING: Cannot use Ledger for orchestrator, so make sure the Ethereum key is accessible outside of it",
-				)
-			}
-
-			valAddress, cosmosKeyring, err := initCosmosKeyring(konfig)
-			if err != nil {
-				return fmt.Errorf("failed to initialize Cosmos keyring: %w", err)
-			}
-
-			logger, err := getLogger(cmd)
-			if err != nil {
-				return err
-			}
-
-			ethKeyFromAddress, _, personalSignFn, err := initEthereumAccountsManager(logger, 0, konfig)
-			if err != nil {
-				return fmt.Errorf("failed to initialize Ethereum account: %w", err)
-			}
-
-			fmt.Fprintf(os.Stderr, "Using Cosmos validator address: %s\n", sdk.ValAddress(valAddress))
-			fmt.Fprintf(os.Stderr, "Using Ethereum address: %s\n", ethKeyFromAddress)
-
-			autoConfirm := konfig.Bool(flagAutoConfirm)
-			actionConfirmed := autoConfirm || stdinConfirm("Confirm UpdatePeggyOrchestratorAddresses transaction? [y/N]: ")
-			if !actionConfirmed {
-				return nil
-			}
-
-			cosmosChainID := konfig.String(flagCosmosChainID)
-			clientCtx, err := client.NewClientContext(cosmosChainID, valAddress.String(), cosmosKeyring)
-			if err != nil {
-				return err
-			}
-
-			tmRPCEndpoint := konfig.String(flagTendermintRPC)
-			cosmosGRPC := konfig.String(flagCosmosGRPC)
-			cosmosGasPrices := konfig.String(flagCosmosGasPrices)
-
-			tmRPC, err := rpchttp.New(tmRPCEndpoint, "/websocket")
-			if err != nil {
-				return fmt.Errorf("failed to create Tendermint RPC client: %w", err)
-			}
-
-			fmt.Fprintf(os.Stderr, "Connected to Tendermint RPC: %s\n", tmRPCEndpoint)
-			clientCtx = clientCtx.WithClient(tmRPC).WithNodeURI(tmRPCEndpoint)
-
-			daemonClient, err := client.NewCosmosClient(clientCtx, logger, cosmosGRPC, client.OptionGasPrices(cosmosGasPrices))
-			if err != nil {
-				return err
-			}
-
-			// TODO: Clean this up to be more ergonomic and clean. We can probably
-			// encapsulate all of this into a single utility function that gracefully
-			// checks for the gRPC status/health.
-			//
-			// Ref: https://github.com/umee-network/peggo/issues/2
-			fmt.Fprintln(os.Stderr, "Waiting for cosmos gRPC service...")
-			time.Sleep(time.Second)
-
-			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-			defer cancel()
-
-			gRPCConn := daemonClient.QueryClient()
-			waitForService(ctx, gRPCConn)
-
-			peggyQuerier := peggytypes.NewQueryClient(gRPCConn)
-			peggyBroadcaster := cosmos.NewPeggyBroadcastClient(logger, peggyQuerier, daemonClient, nil, personalSignFn)
-
-			ctx, cancel = context.WithTimeout(context.Background(), 15*time.Second)
-			defer cancel()
-
-			if err = peggyBroadcaster.UpdatePeggyOrchestratorAddresses(ctx, ethKeyFromAddress, valAddress); err != nil {
-				return fmt.Errorf("failed to broadcast transaction: %w", err)
-			}
-
-			fmt.Fprintf(
-				os.Stderr, "Registered Ethereum Address %s for validator %s\n",
-				ethKeyFromAddress,
-				sdk.ValAddress(valAddress),
-			)
-			return nil
-		},
-	}
-
-	cmd.Flags().BoolP(flagAutoConfirm, "y", false, "Auto-confirm actions (e.g. transaction sending)")
-	cmd.Flags().AddFlagSet(cosmosFlagSet())
-	cmd.Flags().AddFlagSet(cosmosKeyringFlagSet())
-	cmd.Flags().AddFlagSet(ethereumKeyOptsFlagSet())
 
 	return cmd
 }

--- a/cmd/peggo/util.go
+++ b/cmd/peggo/util.go
@@ -12,25 +12,6 @@ import (
 	"google.golang.org/grpc/connectivity"
 )
 
-func stdinConfirm(msg string) bool {
-	var response string
-
-	fmt.Fprint(os.Stderr, msg)
-
-	if _, err := fmt.Scanln(&response); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to confirm action: %s\n", err)
-		return false
-	}
-
-	switch strings.ToLower(strings.TrimSpace(response)) {
-	case "y", "yes":
-		return true
-
-	default:
-		return false
-	}
-}
-
 func hexToBytes(str string) ([]byte, error) {
 	str = strings.TrimPrefix(str, "0x")
 


### PR DESCRIPTION
This command was moved to the Peggy module as `set-orchestrator-address`