### PR TITLE
feat: Add gas limit adjustment flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Improvements
+
+- [#105] Added a gas limit adjustment flag for Ethereum transactions.
+
 ## [v0.1.0](https://github.com/umee-network/peggo/releases/tag/v0.1.0) - 2021-12-18
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - [#105] Added a gas limit adjustment flag for Ethereum transactions.
 
 ## [v0.1.0](https://github.com/umee-network/peggo/releases/tag/v0.1.0) - 2021-12-18
+
 ### Features
 
 - Initial release!!!

--- a/cmd/peggo/flags.go
+++ b/cmd/peggo/flags.go
@@ -32,6 +32,7 @@ const (
 	flagEthUseLedger            = "eth-use-ledger"
 	flagEthRPC                  = "eth-rpc"
 	flagEthGasAdjustment        = "eth-gas-price-adjustment"
+	flagEthGasLimitAdjustment   = "eth-gas-limit-adjustment"
 	flagEthAlchemyWS            = "eth-alchemy-ws"
 	flagRelayValsets            = "relay-valsets"
 	flagRelayBatches            = "relay-batches"
@@ -89,6 +90,7 @@ func ethereumOptsFlagSet() *pflag.FlagSet {
 
 	fs.String(flagEthRPC, "http://localhost:8545", "Specify the RPC address of an Ethereum node")
 	fs.Float64(flagEthGasAdjustment, float64(1.3), "Specify a gas price adjustment for Ethereum transactions")
+	fs.Float64(flagEthGasLimitAdjustment, float64(1.2), "Specify a gas limit adjustment for Ethereum transactions")
 
 	return fs
 }

--- a/cmd/peggo/orchestrator.go
+++ b/cmd/peggo/orchestrator.go
@@ -124,10 +124,12 @@ func getOrchestratorCmd() *cobra.Command {
 			ethProvider := provider.NewEVMProvider(ethRPC)
 
 			ethGasPriceAdjustment := konfig.Float64(flagEthGasAdjustment)
+			ethGasLimitAdjustment := konfig.Float64(flagEthGasLimitAdjustment)
 			ethCommitter, err := committer.NewEthCommitter(
 				logger,
 				ethKeyFromAddress,
 				ethGasPriceAdjustment,
+				ethGasLimitAdjustment,
 				signerFn,
 				ethProvider,
 			)

--- a/orchestrator/eth_event_watcher_test.go
+++ b/orchestrator/eth_event_watcher_test.go
@@ -120,6 +120,7 @@ func TestCheckForEvents(t *testing.T) {
 			logger,
 			fromAddress,
 			ethGasPriceAdjustment,
+			1.0,
 			nil,
 			ethProvider,
 		)
@@ -207,6 +208,7 @@ func TestCheckForEvents(t *testing.T) {
 		ethCommitter, _ := committer.NewEthCommitter(
 			logger,
 			fromAddress,
+			1.0,
 			1.0,
 			nil,
 			ethProvider,
@@ -313,6 +315,7 @@ func TestCheckForEvents(t *testing.T) {
 			logger,
 			fromAddress,
 			ethGasPriceAdjustment,
+			1.0,
 			nil,
 			ethProvider,
 		)
@@ -431,6 +434,7 @@ func TestCheckForEvents(t *testing.T) {
 			logger,
 			fromAddress,
 			ethGasPriceAdjustment,
+			1.0,
 			nil,
 			ethProvider,
 		)
@@ -563,6 +567,7 @@ func TestCheckForEvents(t *testing.T) {
 			logger,
 			fromAddress,
 			ethGasPriceAdjustment,
+			1.0,
 			nil,
 			ethProvider,
 		)

--- a/orchestrator/ethereum/peggy/peggy_contract_test.go
+++ b/orchestrator/ethereum/peggy/peggy_contract_test.go
@@ -48,6 +48,7 @@ func TestGetTxBatchNonce(t *testing.T) {
 		logger,
 		common.Address{},
 		1.0,
+		1.0,
 		nil,
 		mockEvmProvider,
 	)
@@ -86,6 +87,7 @@ func TestGetValsetNonce(t *testing.T) {
 		logger,
 		common.Address{},
 		1.0,
+		1.0,
 		nil,
 		mockEvmProvider,
 	)
@@ -122,6 +124,7 @@ func TestGetGetPeggyID(t *testing.T) {
 	ethCommitter, _ := committer.NewEthCommitter(
 		logger,
 		common.Address{},
+		1.0,
 		1.0,
 		nil,
 		mockEvmProvider,
@@ -167,6 +170,7 @@ func TestGetERC20Symbol(t *testing.T) {
 		logger,
 		common.Address{},
 		1.0,
+		1.0,
 		nil,
 		mockEvmProvider,
 	)
@@ -210,6 +214,7 @@ func TestGetERC20Decimals(t *testing.T) {
 		logger,
 		common.Address{},
 		1.0,
+		1.0,
 		nil,
 		mockEvmProvider,
 	)
@@ -234,6 +239,7 @@ func TestAddress(t *testing.T) {
 	ethCommitter, _ := committer.NewEthCommitter(
 		logger,
 		common.Address{},
+		1.0,
 		1.0,
 		nil,
 		mockEvmProvider,

--- a/orchestrator/ethereum/peggy/pending_transactions_test.go
+++ b/orchestrator/ethereum/peggy/pending_transactions_test.go
@@ -57,6 +57,7 @@ func TestIsPendingTxInput(t *testing.T) {
 		logger,
 		common.Address{},
 		1.0,
+		1.0,
 		nil,
 		mockEvmProvider,
 	)

--- a/orchestrator/ethereum/peggy/submit_batch_test.go
+++ b/orchestrator/ethereum/peggy/submit_batch_test.go
@@ -31,6 +31,7 @@ func TestEncodeTransactionBatch(t *testing.T) {
 		logger,
 		common.Address{},
 		1.0,
+		1.0,
 		nil,
 		mockEvmProvider,
 	)

--- a/orchestrator/ethereum/peggy/valset_update_test.go
+++ b/orchestrator/ethereum/peggy/valset_update_test.go
@@ -31,6 +31,7 @@ func TestEncodeValsetUpdate(t *testing.T) {
 		logger,
 		common.Address{},
 		1.0,
+		1.0,
 		nil,
 		mockEvmProvider,
 	)

--- a/orchestrator/oracle_resync_test.go
+++ b/orchestrator/oracle_resync_test.go
@@ -46,6 +46,7 @@ func TestGetLastCheckedBlock(t *testing.T) {
 		logger,
 		fromAddress,
 		ethGasPriceAdjustment,
+		1.0,
 		nil,
 		ethProvider,
 	)

--- a/orchestrator/relayer/batch_relaying_test.go
+++ b/orchestrator/relayer/batch_relaying_test.go
@@ -53,6 +53,7 @@ func TestIsBatchProfitable(t *testing.T) {
 		logger,
 		fromAddress,
 		1.0,
+		1.0,
 		nil,
 		ethProvider,
 	)


### PR DESCRIPTION
Adds a flag so the gas limit is estimatedGasCost*gasLimitAdj. By default we use 1.2 as the multiplier.

Thanks @Hsiang-xxs for the suggestions 🙏 

Closes #98