### PR TITLE
fix: Cleanup and updates from Gravity Bridge

### DIFF
--- a/cmd/peggo/flags.go
+++ b/cmd/peggo/flags.go
@@ -45,6 +45,7 @@ const (
 	flagProfitMultiplier        = "profit-multiplier"
 	flagRelayerLoopMultiplier   = "relayer-loop-multiplier"
 	flagRequesterLoopMultiplier = "requester-loop-multiplier"
+	flagBridgeStartHeight       = "bridge-start-height"
 )
 
 func cosmosFlagSet() *pflag.FlagSet {

--- a/cmd/peggo/orchestrator.go
+++ b/cmd/peggo/orchestrator.go
@@ -216,6 +216,7 @@ func getOrchestratorCmd() *cobra.Command {
 				averageEthBlockTime,
 				batchRequesterLoopDuration,
 				konfig.Int64(flagEthBlocksPerLoop),
+				konfig.Int64(flagBridgeStartHeight),
 			)
 
 			ctx, cancel = context.WithCancel(context.Background())
@@ -250,6 +251,7 @@ func getOrchestratorCmd() *cobra.Command {
 	cmd.Flags().Float64(flagRelayerLoopMultiplier, 3.0, "Multiplier for the relayer loop duration (in ETH blocks)")
 	cmd.Flags().Float64(flagRequesterLoopMultiplier, 60.0, "Multiplier for the batch requester loop duration (in Cosmos blocks)")
 	cmd.Flags().String(flagCosmosFeeGranter, "", "Set an (optional) fee granter address that will pay for Cosmos fees (feegrant must exist)")
+	cmd.Flags().Int64(flagBridgeStartHeight, 0, "Set an (optional) height to wait for the bridge to be available")
 	cmd.Flags().AddFlagSet(cosmosFlagSet())
 	cmd.Flags().AddFlagSet(cosmosKeyringFlagSet())
 	cmd.Flags().AddFlagSet(ethereumKeyOptsFlagSet())

--- a/orchestrator/eth_event_watcher_test.go
+++ b/orchestrator/eth_event_watcher_test.go
@@ -161,6 +161,7 @@ func TestCheckForEvents(t *testing.T) {
 			time.Second,
 			time.Second,
 			100,
+			0,
 		)
 
 		currentBlock, err := orch.CheckForEvents(context.Background(), 1, 5)
@@ -239,6 +240,7 @@ func TestCheckForEvents(t *testing.T) {
 			time.Second,
 			time.Second,
 			100,
+			0,
 		)
 
 		currentBlock, err := orch.CheckForEvents(context.Background(), 1, 5)
@@ -344,6 +346,7 @@ func TestCheckForEvents(t *testing.T) {
 			time.Second,
 			time.Second,
 			100,
+			0,
 		)
 
 		currentBlock, err := orch.CheckForEvents(context.Background(), 1, 5)
@@ -463,6 +466,7 @@ func TestCheckForEvents(t *testing.T) {
 			time.Second,
 			time.Second,
 			100,
+			0,
 		)
 
 		currentBlock, err := orch.CheckForEvents(context.Background(), 1, 5)
@@ -596,6 +600,7 @@ func TestCheckForEvents(t *testing.T) {
 			time.Second,
 			time.Second,
 			100,
+			0,
 		)
 
 		currentBlock, err := orch.CheckForEvents(context.Background(), 1, 5)

--- a/orchestrator/ethereum/gravity/peggy_contract.go
+++ b/orchestrator/ethereum/gravity/peggy_contract.go
@@ -262,7 +262,8 @@ func sigToVRS(sigHex string) (v uint8, r, s ethcmn.Hash) {
 	return
 }
 
-// gravityPowerToPercent takes in an amount of power in the Gravity Bridge, returns a percentage of total
+// gravityPowerToPercent takes in an amount of power in the Gravity Bridge, returns a percentage of total. Use this for
+// printing values to users only, for accurate calculations use gravityPowerToPass
 func gravityPowerToPercent(total *big.Int) float32 {
 	d := decimal.NewFromBigInt(total, 0)
 	f, _ := d.Div(decimal.NewFromInt(totalGravityPower)).Shift(2).Float64()

--- a/orchestrator/ethereum/gravity/peggy_contract.go
+++ b/orchestrator/ethereum/gravity/peggy_contract.go
@@ -268,3 +268,8 @@ func gravityPowerToPercent(total *big.Int) float32 {
 	f, _ := d.Div(decimal.NewFromInt(totalGravityPower)).Shift(2).Float64()
 	return float32(f)
 }
+
+// isEnoughPower compares a power value to the power required to pass (a constant)
+func isEnoughPower(total *big.Int) bool {
+	return total.Cmp(big.NewInt(gravityPowerToPass)) == 1
+}

--- a/orchestrator/ethereum/gravity/peggy_contract.go
+++ b/orchestrator/ethereum/gravity/peggy_contract.go
@@ -2,7 +2,6 @@ package gravity
 
 import (
 	"context"
-	"math"
 	"math/big"
 	"strings"
 	"sync"
@@ -17,11 +16,6 @@ import (
 	"github.com/umee-network/peggo/orchestrator/ethereum/committer"
 	wrappers "github.com/umee-network/peggo/solwrappers/Gravity.sol"
 )
-
-// The total power in the Gravity bridge is normalized to u32 max every
-// time a validator set is created. This value of up to u32 max is then
-// stored in a i64 to prevent overflow during computation.
-const totalGravityPower int64 = math.MaxUint32
 
 // gravityPowerToPass is a mirror of constant_powerThreshold in Gravity.sol
 const gravityPowerToPass int64 = 2863311530

--- a/orchestrator/ethereum/gravity/peggy_contract.go
+++ b/orchestrator/ethereum/gravity/peggy_contract.go
@@ -24,6 +24,9 @@ import (
 // stored in a i64 to prevent overflow during computation.
 const totalGravityPower int64 = math.MaxUint32
 
+// gravityPowerToPass is a mirror of constant_powerThreshold in Gravity.sol
+const gravityPowerToPass int64 = 2863311530
+
 var (
 	gravityABI, _ = abi.JSON(strings.NewReader(wrappers.GravityABI))
 

--- a/orchestrator/ethereum/gravity/peggy_contract.go
+++ b/orchestrator/ethereum/gravity/peggy_contract.go
@@ -14,7 +14,6 @@ import (
 	ethcmn "github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
-	"github.com/shopspring/decimal"
 	"github.com/umee-network/peggo/orchestrator/ethereum/committer"
 	wrappers "github.com/umee-network/peggo/solwrappers/Gravity.sol"
 )
@@ -260,14 +259,6 @@ func sigToVRS(sigHex string) (v uint8, r, s ethcmn.Hash) {
 	s = ethcmn.BytesToHash(signatureBytes[32:64])
 
 	return
-}
-
-// gravityPowerToPercent takes in an amount of power in the Gravity Bridge, returns a percentage of total. Use this for
-// printing values to users only, for accurate calculations use gravityPowerToPass
-func gravityPowerToPercent(total *big.Int) float32 {
-	d := decimal.NewFromBigInt(total, 0)
-	f, _ := d.Div(decimal.NewFromInt(totalGravityPower)).Shift(2).Float64()
-	return float32(f)
 }
 
 // isEnoughPower compares a power value to the power required to pass (a constant)

--- a/orchestrator/ethereum/gravity/peggy_contract_test.go
+++ b/orchestrator/ethereum/gravity/peggy_contract_test.go
@@ -17,12 +17,6 @@ import (
 	wrappers "github.com/umee-network/peggo/solwrappers/Gravity.sol"
 )
 
-func TestGravityPowerToPercent(t *testing.T) {
-	percent := gravityPowerToPercent(big.NewInt(213192100))
-	assert.Equal(t, percent, float32(4.9637656))
-
-}
-
 func TestGetTxBatchNonce(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()

--- a/orchestrator/ethereum/gravity/submit_batch.go
+++ b/orchestrator/ethereum/gravity/submit_batch.go
@@ -34,8 +34,10 @@ func (s *gravityContract) EncodeTransactionBatch(
 
 	sigs, err := checkBatchSigsAndRepack(currentValset, confirms)
 	if err != nil {
-		err = errors.Wrap(err, "confirmations check failed")
-		return nil, err
+		s.logger.Debug().
+			AnErr("err", err).
+			Msg("confirmations check failed")
+		return nil, nil
 	}
 
 	amounts, destinations, fees := getBatchCheckpointValues(batch)

--- a/orchestrator/ethereum/gravity/submit_batch.go
+++ b/orchestrator/ethereum/gravity/submit_batch.go
@@ -146,10 +146,11 @@ func checkAndRepackSigs(valset types.Valset, confirms []genericConfirm) (*Repack
 			sigs.s = append(sigs.s, [32]byte{})
 		}
 	}
-	if gravityPowerToPercent(powerOfGoodSigs) < 66 {
-		err = ErrInsufficientVotingPowerToPass
+
+	if isEnoughPower(powerOfGoodSigs) {
 		return sigs, err
 	}
 
+	err = ErrInsufficientVotingPowerToPass
 	return sigs, err
 }

--- a/orchestrator/ethereum/gravity/valset_update.go
+++ b/orchestrator/ethereum/gravity/valset_update.go
@@ -41,8 +41,10 @@ func (s *gravityContract) EncodeValsetUpdate(
 	// members of the validator set in the contract.
 	sigs, err := checkValsetSigsAndRepack(oldValset, confirms)
 	if err != nil {
-		err = errors.Wrap(err, "confirmations check failed")
-		return nil, err
+		s.logger.Debug().
+			AnErr("err", err).
+			Msg("confirmations check failed")
+		return nil, nil
 	}
 	currentValsetNonce := new(big.Int).SetUint64(oldValset.Nonce)
 	currentValsetArgs := wrappers.ValsetArgs{

--- a/orchestrator/main_loops.go
+++ b/orchestrator/main_loops.go
@@ -343,13 +343,16 @@ func (p *gravityOrchestrator) ERC20ToDenom(ctx context.Context, tokenAddr ethcmn
 
 // getEthBlockDelay returns the right amount of Ethereum blocks to wait until we
 // consider a block final. This depends on the chain we are talking to.
-// Copying from https://github.com/althea-net/cosmos-gravity-bridge/blob/main/orchestrator/orchestrator/src/ethereum_event_watcher.rs#L222
+// Copying from https://github.com/Gravity-Bridge/Gravity-Bridge/blob/main/orchestrator/orchestrator/src/ethereum_event_watcher.rs#L248
+// DO NOT MODIFY. Changing any of these values puts the network in DANGER and
+// does not provide any advantage over other validators. This is a safety
+// mechanism to prevent relaying an event that is not yet considered final.
 func getEthBlockDelay(chainID uint64) uint64 {
 	switch chainID {
 	// Mainline Ethereum, Ethereum classic, or the Ropsten, Kotti, Mordor testnets
 	// all POW Chains
 	case 1, 3, 6, 7:
-		return 6
+		return 13
 
 	// Dev, our own Gravity Ethereum testnet, and Hardhat respectively
 	// all single signer chains with no chance of any reorgs
@@ -364,6 +367,6 @@ func getEthBlockDelay(chainID uint64) uint64 {
 
 	// assume the safe option (POW) where we don't know
 	default:
-		return 6
+		return 13
 	}
 }

--- a/orchestrator/main_loops.go
+++ b/orchestrator/main_loops.go
@@ -75,9 +75,6 @@ func (p *gravityOrchestrator) EthOracleMainLoop(ctx context.Context) (err error)
 
 	if err := retry.Do(func() (err error) {
 		lastCheckedBlock, err = p.GetLastCheckedBlock(ctx, getEthBlockDelay(gravityParams.BridgeChainId))
-		if lastCheckedBlock == 0 {
-			lastCheckedBlock = p.startingEthBlock
-		}
 
 		return err
 	}, retry.Context(ctx), retry.OnRetry(func(n uint, err error) {

--- a/orchestrator/main_loops.go
+++ b/orchestrator/main_loops.go
@@ -18,11 +18,11 @@ const (
 
 	// Run every approximately 5 Ethereum blocks to allow time to receive new blocks.
 	// If we run this faster we wouldn't be getting new blocks, which is not efficient.
-	ethOracleLoopMultiplier = 1
+	ethOracleLoopMultiplier = 5
 
 	// Run every approximately 3 Cosmos blocks; so we sign batches and valset updates ASAP but not run these requests
 	// too often that we make too many requests to Cosmos.
-	ethSignerLoopMultiplier = 1
+	ethSignerLoopMultiplier = 3
 )
 
 // Start combines the all major roles required to make

--- a/orchestrator/main_loops_test.go
+++ b/orchestrator/main_loops_test.go
@@ -54,8 +54,8 @@ func TestERC20ToDenom(t *testing.T) {
 }
 
 func TestGetEthBlockDelay(t *testing.T) {
-	assert.Equal(t, uint64(6), getEthBlockDelay(1))
+	assert.Equal(t, uint64(13), getEthBlockDelay(1))
 	assert.Equal(t, uint64(0), getEthBlockDelay(2018))
 	assert.Equal(t, uint64(10), getEthBlockDelay(5))
-	assert.Equal(t, uint64(6), getEthBlockDelay(1235))
+	assert.Equal(t, uint64(13), getEthBlockDelay(1235))
 }

--- a/orchestrator/oracle_resync.go
+++ b/orchestrator/oracle_resync.go
@@ -107,10 +107,36 @@ func (p *gravityOrchestrator) GetLastCheckedBlock(
 
 		iterTXBatchExec.Close()
 
-		// this reverse solves a very specific bug, we use the properties of the first valsets for edgecase
+		iterErc20Deploy, err := gravityFilterer.FilterERC20DeployedEvent(&bind.FilterOpts{
+			Start: endSearch,
+			End:   &currentBlock,
+		}, nil)
+		if err != nil {
+			p.logger.Err(err).
+				Uint64("start", endSearch).
+				Uint64("end", currentBlock).
+				Msg("failed to scan past ERC20Deployed events from Ethereum")
+
+			if !isUnknownBlockErr(err) {
+				err = errors.Wrap(err, "failed to scan past ERC20Deployed events from Ethereum")
+				return 0, err
+			} else if iterErc20Deploy == nil {
+				return 0, errors.New("no iterator returned")
+			}
+		}
+
+		for iterErc20Deploy.Next() {
+			if iterErc20Deploy.Event.EventNonce.Uint64() == lastEventNonce {
+				return iterErc20Deploy.Event.Raw.BlockNumber, nil
+			}
+		}
+
+		iterErc20Deploy.Close()
+
+		// This reverse solves a very specific bug, we use the properties of the first valsets for edgecase
 		// handling here, but events come in chronological order, so if we don't reverse the iterator
 		// we will encounter the first validator sets first and exit early and incorrectly.
-		// note that reversing everything won't actually get you that much of a performance gain
+		// Note that reversing everything won't actually get you that much of a performance gain
 		// because this only involves events within the searching block range.
 		var valsetUpdatedEvents []*wrappers.GravityValsetUpdatedEvent
 		{
@@ -139,7 +165,7 @@ func (p *gravityOrchestrator) GetLastCheckedBlock(
 			iter.Close()
 		}
 
-		// there's no easy way to reverse the list, so we have to do it manually
+		// There's no easy way to reverse the list, so we have to do it manually.
 		for i := 0; i < len(valsetUpdatedEvents)/2; i++ {
 			j := len(valsetUpdatedEvents) - i - 1
 			valsetUpdatedEvents[i], valsetUpdatedEvents[j] = valsetUpdatedEvents[j], valsetUpdatedEvents[i]
@@ -152,36 +178,11 @@ func (p *gravityOrchestrator) GetLastCheckedBlock(
 			if commonCase || bootstrapping {
 				return valset.Raw.BlockNumber, nil
 			} else if valset.NewValsetNonce.Uint64() == 0 && lastEventNonce > 1 {
-				// TODO: avoid panic until we find the cause
+				// If another iterator is added below the valset iterator, this panic will be triggered. Add new
+				// iterators above.
 				p.logger.Panic().Msg("could not find the last event relayed")
 			}
 		}
-
-		iterErc20Deploy, err := gravityFilterer.FilterERC20DeployedEvent(&bind.FilterOpts{
-			Start: endSearch,
-			End:   &currentBlock,
-		}, nil)
-		if err != nil {
-			p.logger.Err(err).
-				Uint64("start", endSearch).
-				Uint64("end", currentBlock).
-				Msg("failed to scan past ERC20Deployed events from Ethereum")
-
-			if !isUnknownBlockErr(err) {
-				err = errors.Wrap(err, "failed to scan past ERC20Deployed events from Ethereum")
-				return 0, err
-			} else if iterErc20Deploy == nil {
-				return 0, errors.New("no iterator returned")
-			}
-		}
-
-		for iterErc20Deploy.Next() {
-			if iterErc20Deploy.Event.EventNonce.Uint64() == lastEventNonce {
-				return iterErc20Deploy.Event.Raw.BlockNumber, nil
-			}
-		}
-
-		iterErc20Deploy.Close()
 
 		currentBlock = endSearch
 	}

--- a/orchestrator/oracle_resync.go
+++ b/orchestrator/oracle_resync.go
@@ -152,7 +152,8 @@ func (p *gravityOrchestrator) GetLastCheckedBlock(
 			if commonCase || bootstrapping {
 				return valset.Raw.BlockNumber, nil
 			} else if valset.NewValsetNonce.Uint64() == 0 && lastEventNonce > 1 {
-				p.logger.Panic().Msg("could not find the last event relayed")
+				// TODO: avoid panic until we find the cause
+				// p.logger.Panic().Msg("could not find the last event relayed")
 			}
 		}
 

--- a/orchestrator/oracle_resync.go
+++ b/orchestrator/oracle_resync.go
@@ -139,24 +139,6 @@ func (p *gravityOrchestrator) GetLastCheckedBlock(
 			iter.Close()
 		}
 
-		// there's no easy way to reverse the list, so we have to do it manually
-		for i := 0; i < len(valsetUpdatedEvents)/2; i++ {
-			j := len(valsetUpdatedEvents) - i - 1
-			valsetUpdatedEvents[i], valsetUpdatedEvents[j] = valsetUpdatedEvents[j], valsetUpdatedEvents[i]
-		}
-
-		for _, valset := range valsetUpdatedEvents {
-			bootstrapping := valset.NewValsetNonce.Uint64() == 0 && lastEventNonce == 1
-			commonCase := valset.EventNonce.Uint64() == lastEventNonce
-
-			if commonCase || bootstrapping {
-				return valset.Raw.BlockNumber, nil
-			} else if valset.NewValsetNonce.Uint64() == 0 && lastEventNonce > 1 {
-				// TODO: avoid panic until we find the cause
-				// p.logger.Panic().Msg("could not find the last event relayed")
-			}
-		}
-
 		iterErc20Deploy, err := gravityFilterer.FilterERC20DeployedEvent(&bind.FilterOpts{
 			Start: endSearch,
 			End:   &currentBlock,
@@ -182,6 +164,23 @@ func (p *gravityOrchestrator) GetLastCheckedBlock(
 		}
 
 		iterErc20Deploy.Close()
+
+		// there's no easy way to reverse the list, so we have to do it manually
+		for i := 0; i < len(valsetUpdatedEvents)/2; i++ {
+			j := len(valsetUpdatedEvents) - i - 1
+			valsetUpdatedEvents[i], valsetUpdatedEvents[j] = valsetUpdatedEvents[j], valsetUpdatedEvents[i]
+		}
+
+		for _, valset := range valsetUpdatedEvents {
+			bootstrapping := valset.NewValsetNonce.Uint64() == 0 && lastEventNonce == 1
+			commonCase := valset.EventNonce.Uint64() == lastEventNonce
+
+			if commonCase || bootstrapping {
+				return valset.Raw.BlockNumber, nil
+			} else if valset.NewValsetNonce.Uint64() == 0 && lastEventNonce > 1 {
+				p.logger.Panic().Msg("could not find the last event relayed")
+			}
+		}
 
 		currentBlock = endSearch
 	}

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -39,6 +39,7 @@ type gravityOrchestrator struct {
 	ethereumBlockTime          time.Duration
 	batchRequesterLoopDuration time.Duration
 	ethBlocksPerLoop           uint64
+	bridgeStartHeight          uint64
 
 	mtx             sync.Mutex
 	erc20DenomCache map[string]string
@@ -57,6 +58,7 @@ func NewGravityOrchestrator(
 	ethereumBlockTime time.Duration,
 	batchRequesterLoopDuration time.Duration,
 	ethBlocksPerLoop int64,
+	bridgeStartHeight int64,
 	options ...func(GravityOrchestrator),
 ) GravityOrchestrator {
 
@@ -74,6 +76,7 @@ func NewGravityOrchestrator(
 		ethereumBlockTime:          ethereumBlockTime,
 		batchRequesterLoopDuration: batchRequesterLoopDuration,
 		ethBlocksPerLoop:           uint64(ethBlocksPerLoop),
+		bridgeStartHeight:          uint64(bridgeStartHeight),
 	}
 
 	for _, option := range options {

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -38,7 +38,6 @@ type gravityOrchestrator struct {
 	cosmosBlockTime            time.Duration
 	ethereumBlockTime          time.Duration
 	batchRequesterLoopDuration time.Duration
-	startingEthBlock           uint64
 	ethBlocksPerLoop           uint64
 
 	mtx             sync.Mutex
@@ -75,7 +74,6 @@ func NewGravityOrchestrator(
 		ethereumBlockTime:          ethereumBlockTime,
 		batchRequesterLoopDuration: batchRequesterLoopDuration,
 		ethBlocksPerLoop:           uint64(ethBlocksPerLoop),
-		startingEthBlock:           uint64(6149808),
 	}
 
 	for _, option := range options {

--- a/orchestrator/relayer/batch_relaying.go
+++ b/orchestrator/relayer/batch_relaying.go
@@ -155,6 +155,10 @@ func (s *gravityRelayer) RelayBatches(
 				return err
 			}
 
+			if txData == nil {
+				continue
+			}
+
 			estimatedGasCost, gasPrice, err := s.gravityContract.EstimateGas(ctx, s.gravityContract.Address(), txData)
 			if err != nil {
 				s.logger.Err(err).Msg("failed to estimate gas cost")

--- a/orchestrator/relayer/valset_relaying.go
+++ b/orchestrator/relayer/valset_relaying.go
@@ -83,6 +83,10 @@ func (s *gravityRelayer) RelayValsets(ctx context.Context, currentValset types.V
 				return err
 			}
 
+			if txData == nil {
+				return nil
+			}
+
 			estimatedGasCost, gasPrice, err := s.gravityContract.EstimateGas(ctx, s.gravityContract.Address(), txData)
 			if err != nil {
 				s.logger.Err(err).Msg("failed to estimate gas cost")


### PR DESCRIPTION
Fixes and refactors:

- fix hardcoded loop durations (they were changed while testing)
- fix panic on GetLastCheckedBlock (it was a matter of checking valsets last)
- added waiting loop until bridge gets deployed, if bridge-start-height is set only.
- fix power check using ints instead of percentages (ints are more accurate)
- fix retry of batches/valsets with missing confirmations. We skip those, as retrying right after doesn't help. We might need to implement a different solution if we want a more aggressive/competitive behavior.
- fix some names
- removed dead code