### PR TITLE
test: Enable running tests with Ganache + test refactor + use gentx for Gravity keys

### DIFF
--- a/cmd/peggo/bridge.go
+++ b/cmd/peggo/bridge.go
@@ -495,7 +495,7 @@ Transaction: %s
 func buildTransactOpts(konfig *koanf.Koanf, ethClient *ethclient.Client) (*bind.TransactOpts, error) {
 	ethPrivKeyHexStr := konfig.String(flagEthPK)
 
-	privKey, err := ethcrypto.HexToECDSA(ethPrivKeyHexStr)
+	privKey, err := ethcrypto.ToECDSA(ethcmn.FromHex(ethPrivKeyHexStr))
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode private key: %w", err)
 	}

--- a/cmd/peggo/keys.go
+++ b/cmd/peggo/keys.go
@@ -263,7 +263,7 @@ func initEthereumAccountsManager(
 		return ethKeyFromAddress, signerFn, personalSignFn, nil
 
 	case len(ethPrivKey) > 0:
-		ethPk, err := ethcrypto.HexToECDSA(ethPrivKey)
+		ethPk, err := ethcrypto.ToECDSA(ethcmn.FromHex(ethPrivKey))
 		if err != nil {
 			return emptyEthAddress, nil, nil, fmt.Errorf("failed to hex-decode Ethereum ECDSA Private Key: %w", err)
 		}

--- a/orchestrator/oracle_resync_test.go
+++ b/orchestrator/oracle_resync_test.go
@@ -1,428 +1,165 @@
 package orchestrator
 
-// import (
-// 	"context"
-// 	"os"
-// 	"testing"
-// 	"time"
-
-// 	"github.com/Gravity-Bridge/Gravity-Bridge/module/x/gravity/types"
-// 	sdk "github.com/cosmos/cosmos-sdk/types"
-// 	ethcmn "github.com/ethereum/go-ethereum/common"
-// 	"github.com/golang/mock/gomock"
-// 	"github.com/pkg/errors"
-// 	"github.com/rs/zerolog"
-// 	"github.com/stretchr/testify/assert"
-// 	"github.com/umee-network/peggo/mocks"
-// 	"github.com/umee-network/peggo/orchestrator/cosmos"
-// 	"github.com/umee-network/peggo/orchestrator/ethereum/committer"
-// 	gravity "github.com/umee-network/peggo/orchestrator/ethereum/gravity"
-// )
-
-// func TestGetLastCheckedBlock(t *testing.T) {
-// 	t.Run("ok", func(t *testing.T) {
-// 		mockCtrl := gomock.NewController(t)
-// 		defer mockCtrl.Finish()
-
-// 		logger := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr})
-// 		fromAddress := ethcmn.HexToAddress("0xd8da6bf26964af9d7eed9e03e53415d37aa96045")
-// 		gravityAddress := ethcmn.HexToAddress("0x3bdf8428734244c9e5d82c95d125081939d6d42d")
-
-// 		mockQClient := mocks.NewMockQueryClient(mockCtrl)
-
-// 		mockQClient.EXPECT().LastEventNonceByAddr(gomock.Any(), &types.QueryLastEventNonceByAddrRequest{
-// 			Address: sdk.AccAddress{}.String(),
-// 		}).Return(&types.QueryLastEventNonceByAddrResponse{
-// 			EventNonce: 1,
-// 		}, nil)
-
-// 		ethProvider := mocks.NewMockEVMProviderWithRet(mockCtrl)
-// 		ethProvider.EXPECT().PendingNonceAt(gomock.Any(), fromAddress).Return(uint64(0), nil)
-
-// 		ethGasPriceAdjustment := 1.0
-// 		ethCommitter, _ := committer.NewEthCommitter(
-// 			logger,
-// 			fromAddress,
-// 			ethGasPriceAdjustment,
-// 			1.0,
-// 			nil,
-// 			ethProvider,
-// 		)
-
-// 		gravityContract, _ := gravity.NewGravityContract(logger, ethCommitter, gravityAddress, nil)
-
-// 		mockCosmos := mocks.NewMockCosmosClient(mockCtrl)
-// 		mockCosmos.EXPECT().FromAddress().Return(sdk.AccAddress{}).AnyTimes()
-// 		mockPersonalSignFn := func(account ethcmn.Address, data []byte) (sig []byte, err error) {
-// 			return []byte{}, errors.New("some error during signing")
-// 		}
-
-// 		gravityBroadcastClient := cosmos.NewGravityBroadcastClient(
-// 			logger,
-// 			nil,
-// 			mockCosmos,
-// 			nil,
-// 			mockPersonalSignFn,
-// 		)
-
-// 		orch := NewGravityOrchestrator(
-// 			zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}),
-// 			mockQClient,
-// 			gravityBroadcastClient,
-// 			gravityContract,
-// 			fromAddress,
-// 			nil,
-// 			nil,
-// 			nil,
-// 			time.Second,
-// 			time.Second,
-// 			time.Second,
-// 			100,
-// 		)
-
-// 		block, err := orch.GetLastCheckedBlock(context.Background(), 0)
-// 		assert.Nil(t, err)
-// 		assert.Equal(t, uint64(123), block)
-// 	})
-
-// 	t.Run("error from cosmosQueryClient", func(t *testing.T) {
-// 		mockCtrl := gomock.NewController(t)
-// 		defer mockCtrl.Finish()
-
-// 		logger := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr})
-// 		fromAddress := ethcmn.HexToAddress("0xd8da6bf26964af9d7eed9e03e53415d37aa96045")
-// 		gravityAddress := ethcmn.HexToAddress("0x3bdf8428734244c9e5d82c95d125081939d6d42d")
-
-// 		mockQClient := mocks.NewMockQueryClient(mockCtrl)
-
-// 		mockQClient.EXPECT().LastEventNonceByAddr(gomock.Any(), &types.QueryLastEventNonceByAddrRequest{
-// 			Address: sdk.AccAddress{}.String(),
-// 		}).Return(&types.QueryLastEventNonceByAddrResponse{
-// 			EventNonce: 1,
-// 		}, errors.New("some error"))
-
-// 		ethProvider := mocks.NewMockEVMProviderWithRet(mockCtrl)
-// 		ethProvider.EXPECT().PendingNonceAt(gomock.Any(), fromAddress).Return(uint64(0), nil)
-
-// 		ethGasPriceAdjustment := 1.0
-// 		ethCommitter, _ := committer.NewEthCommitter(
-// 			logger,
-// 			fromAddress,
-// 			ethGasPriceAdjustment,
-// 			1.0,
-// 			nil,
-// 			ethProvider,
-// 		)
-
-// 		gravityContract, _ := gravity.NewGravityContract(logger, ethCommitter, gravityAddress, nil)
-
-// 		mockCosmos := mocks.NewMockCosmosClient(mockCtrl)
-// 		mockCosmos.EXPECT().FromAddress().Return(sdk.AccAddress{}).AnyTimes()
-// 		mockPersonalSignFn := func(account ethcmn.Address, data []byte) (sig []byte, err error) {
-// 			return []byte{}, errors.New("some error during signing")
-// 		}
-
-// 		gravityBroadcastClient := cosmos.NewGravityBroadcastClient(
-// 			logger,
-// 			nil,
-// 			mockCosmos,
-// 			nil,
-// 			mockPersonalSignFn,
-// 		)
-
-// 		orch := NewGravityOrchestrator(
-// 			zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}),
-// 			mockQClient,
-// 			gravityBroadcastClient,
-// 			gravityContract,
-// 			fromAddress,
-// 			nil,
-// 			nil,
-// 			nil,
-// 			time.Second,
-// 			time.Second,
-// 			time.Second,
-// 			100,
-// 		)
-
-// 		block, err := orch.GetLastCheckedBlock(context.Background(), 0)
-// 		assert.EqualError(t, err, "some error")
-// 		assert.Equal(t, uint64(0), block)
-// 	})
-
-// 	t.Run("error. no response", func(t *testing.T) {
-// 		mockCtrl := gomock.NewController(t)
-// 		defer mockCtrl.Finish()
-
-// 		logger := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr})
-// 		fromAddress := ethcmn.HexToAddress("0xd8da6bf26964af9d7eed9e03e53415d37aa96045")
-// 		gravityAddress := ethcmn.HexToAddress("0x3bdf8428734244c9e5d82c95d125081939d6d42d")
-
-// 		mockQClient := mocks.NewMockQueryClient(mockCtrl)
-// 		mockQClient.EXPECT().LastEventNonceByAddr(gomock.Any(), &types.QueryLastEventNonceByAddrRequest{
-// 			Address: sdk.AccAddress{}.String(),
-// 		}).Return(nil, nil)
-
-// 		ethProvider := mocks.NewMockEVMProviderWithRet(mockCtrl)
-// 		ethProvider.EXPECT().PendingNonceAt(gomock.Any(), fromAddress).Return(uint64(0), nil)
-
-// 		ethGasPriceAdjustment := 1.0
-// 		ethCommitter, _ := committer.NewEthCommitter(
-// 			logger,
-// 			fromAddress,
-// 			ethGasPriceAdjustment,
-// 			1.0,
-// 			nil,
-// 			ethProvider,
-// 		)
-
-// 		gravityContract, _ := gravity.NewGravityContract(logger, ethCommitter, gravityAddress, nil)
-
-// 		mockCosmos := mocks.NewMockCosmosClient(mockCtrl)
-// 		mockCosmos.EXPECT().FromAddress().Return(sdk.AccAddress{}).AnyTimes()
-// 		mockPersonalSignFn := func(account ethcmn.Address, data []byte) (sig []byte, err error) {
-// 			return []byte{}, errors.New("some error during signing")
-// 		}
-
-// 		gravityBroadcastClient := cosmos.NewGravityBroadcastClient(
-// 			logger,
-// 			nil,
-// 			mockCosmos,
-// 			nil,
-// 			mockPersonalSignFn,
-// 		)
-
-// 		orch := NewGravityOrchestrator(
-// 			zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}),
-// 			mockQClient,
-// 			gravityBroadcastClient,
-// 			gravityContract,
-// 			fromAddress,
-// 			nil,
-// 			nil,
-// 			nil,
-// 			time.Second,
-// 			time.Second,
-// 			time.Second,
-// 			100,
-// 		)
-
-// 		block, err := orch.GetLastCheckedBlock(context.Background(), 0)
-// 		assert.EqualError(t, err, "no last event response returned")
-// 		assert.Equal(t, uint64(0), block)
-// 	})
-// }
-// package orchestrator
-
-// import (
-// 	"context"
-// 	"os"
-// 	"testing"
-// 	"time"
-
-// 	"github.com/Gravity-Bridge/Gravity-Bridge/module/x/gravity/types"
-// 	sdk "github.com/cosmos/cosmos-sdk/types"
-// 	ethcmn "github.com/ethereum/go-ethereum/common"
-// 	"github.com/golang/mock/gomock"
-// 	"github.com/pkg/errors"
-// 	"github.com/rs/zerolog"
-// 	"github.com/stretchr/testify/assert"
-// 	"github.com/umee-network/peggo/mocks"
-// 	"github.com/umee-network/peggo/orchestrator/cosmos"
-// 	"github.com/umee-network/peggo/orchestrator/ethereum/committer"
-// 	gravity "github.com/umee-network/peggo/orchestrator/ethereum/gravity"
-// )
-
-// func TestGetLastCheckedBlock(t *testing.T) {
-// 	t.Run("ok", func(t *testing.T) {
-// 		mockCtrl := gomock.NewController(t)
-// 		defer mockCtrl.Finish()
-
-// 		logger := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr})
-// 		fromAddress := ethcmn.HexToAddress("0xd8da6bf26964af9d7eed9e03e53415d37aa96045")
-// 		gravityAddress := ethcmn.HexToAddress("0x3bdf8428734244c9e5d82c95d125081939d6d42d")
-
-// 		mockQClient := mocks.NewMockQueryClient(mockCtrl)
-
-// 		mockQClient.EXPECT().LastEventNonceByAddr(gomock.Any(), &types.QueryLastEventNonceByAddrRequest{
-// 			Address: sdk.AccAddress{}.String(),
-// 		}).Return(&types.QueryLastEventNonceByAddrResponse{
-// 			EventNonce: 1,
-// 		}, nil)
-
-// 		ethProvider := mocks.NewMockEVMProviderWithRet(mockCtrl)
-// 		ethProvider.EXPECT().PendingNonceAt(gomock.Any(), fromAddress).Return(uint64(0), nil)
-
-// 		ethGasPriceAdjustment := 1.0
-// 		ethCommitter, _ := committer.NewEthCommitter(
-// 			logger,
-// 			fromAddress,
-// 			ethGasPriceAdjustment,
-// 			1.0,
-// 			nil,
-// 			ethProvider,
-// 		)
-
-// 		gravityContract, _ := gravity.NewGravityContract(logger, ethCommitter, gravityAddress, nil)
-
-// 		mockCosmos := mocks.NewMockCosmosClient(mockCtrl)
-// 		mockCosmos.EXPECT().FromAddress().Return(sdk.AccAddress{}).AnyTimes()
-// 		mockPersonalSignFn := func(account ethcmn.Address, data []byte) (sig []byte, err error) {
-// 			return []byte{}, errors.New("some error during signing")
-// 		}
-
-// 		gravityBroadcastClient := cosmos.NewGravityBroadcastClient(
-// 			logger,
-// 			nil,
-// 			mockCosmos,
-// 			nil,
-// 			mockPersonalSignFn,
-// 		)
-
-// 		orch := NewGravityOrchestrator(
-// 			zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}),
-// 			mockQClient,
-// 			gravityBroadcastClient,
-// 			gravityContract,
-// 			fromAddress,
-// 			nil,
-// 			nil,
-// 			nil,
-// 			time.Second,
-// 			time.Second,
-// 			time.Second,
-// 			100,
-// 		)
-
-// 		block, err := orch.GetLastCheckedBlock(context.Background(), 0)
-// 		assert.Nil(t, err)
-// 		assert.Equal(t, uint64(123), block)
-// 	})
-
-// 	t.Run("error from cosmosQueryClient", func(t *testing.T) {
-// 		mockCtrl := gomock.NewController(t)
-// 		defer mockCtrl.Finish()
-
-// 		logger := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr})
-// 		fromAddress := ethcmn.HexToAddress("0xd8da6bf26964af9d7eed9e03e53415d37aa96045")
-// 		gravityAddress := ethcmn.HexToAddress("0x3bdf8428734244c9e5d82c95d125081939d6d42d")
-
-// 		mockQClient := mocks.NewMockQueryClient(mockCtrl)
-
-// 		mockQClient.EXPECT().LastEventNonceByAddr(gomock.Any(), &types.QueryLastEventNonceByAddrRequest{
-// 			Address: sdk.AccAddress{}.String(),
-// 		}).Return(&types.QueryLastEventNonceByAddrResponse{
-// 			EventNonce: 1,
-// 		}, errors.New("some error"))
-
-// 		ethProvider := mocks.NewMockEVMProviderWithRet(mockCtrl)
-// 		ethProvider.EXPECT().PendingNonceAt(gomock.Any(), fromAddress).Return(uint64(0), nil)
-
-// 		ethGasPriceAdjustment := 1.0
-// 		ethCommitter, _ := committer.NewEthCommitter(
-// 			logger,
-// 			fromAddress,
-// 			ethGasPriceAdjustment,
-// 			1.0,
-// 			nil,
-// 			ethProvider,
-// 		)
-
-// 		gravityContract, _ := gravity.NewGravityContract(logger, ethCommitter, gravityAddress, nil)
-
-// 		mockCosmos := mocks.NewMockCosmosClient(mockCtrl)
-// 		mockCosmos.EXPECT().FromAddress().Return(sdk.AccAddress{}).AnyTimes()
-// 		mockPersonalSignFn := func(account ethcmn.Address, data []byte) (sig []byte, err error) {
-// 			return []byte{}, errors.New("some error during signing")
-// 		}
-
-// 		gravityBroadcastClient := cosmos.NewGravityBroadcastClient(
-// 			logger,
-// 			nil,
-// 			mockCosmos,
-// 			nil,
-// 			mockPersonalSignFn,
-// 		)
-
-// 		orch := NewGravityOrchestrator(
-// 			zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}),
-// 			mockQClient,
-// 			gravityBroadcastClient,
-// 			gravityContract,
-// 			fromAddress,
-// 			nil,
-// 			nil,
-// 			nil,
-// 			time.Second,
-// 			time.Second,
-// 			time.Second,
-// 			100,
-// 		)
-
-// 		block, err := orch.GetLastCheckedBlock(context.Background(), 0)
-// 		assert.EqualError(t, err, "some error")
-// 		assert.Equal(t, uint64(0), block)
-// 	})
-
-// 	t.Run("error. no response", func(t *testing.T) {
-// 		mockCtrl := gomock.NewController(t)
-// 		defer mockCtrl.Finish()
-
-// 		logger := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr})
-// 		fromAddress := ethcmn.HexToAddress("0xd8da6bf26964af9d7eed9e03e53415d37aa96045")
-// 		gravityAddress := ethcmn.HexToAddress("0x3bdf8428734244c9e5d82c95d125081939d6d42d")
-
-// 		mockQClient := mocks.NewMockQueryClient(mockCtrl)
-// 		mockQClient.EXPECT().LastEventNonceByAddr(gomock.Any(), &types.QueryLastEventNonceByAddrRequest{
-// 			Address: sdk.AccAddress{}.String(),
-// 		}).Return(nil, nil)
-
-// 		ethProvider := mocks.NewMockEVMProviderWithRet(mockCtrl)
-// 		ethProvider.EXPECT().PendingNonceAt(gomock.Any(), fromAddress).Return(uint64(0), nil)
-
-// 		ethGasPriceAdjustment := 1.0
-// 		ethCommitter, _ := committer.NewEthCommitter(
-// 			logger,
-// 			fromAddress,
-// 			ethGasPriceAdjustment,
-// 			1.0,
-// 			nil,
-// 			ethProvider,
-// 		)
-
-// 		gravityContract, _ := gravity.NewGravityContract(logger, ethCommitter, gravityAddress, nil)
-
-// 		mockCosmos := mocks.NewMockCosmosClient(mockCtrl)
-// 		mockCosmos.EXPECT().FromAddress().Return(sdk.AccAddress{}).AnyTimes()
-// 		mockPersonalSignFn := func(account ethcmn.Address, data []byte) (sig []byte, err error) {
-// 			return []byte{}, errors.New("some error during signing")
-// 		}
-
-// 		gravityBroadcastClient := cosmos.NewGravityBroadcastClient(
-// 			logger,
-// 			nil,
-// 			mockCosmos,
-// 			nil,
-// 			mockPersonalSignFn,
-// 		)
-
-// 		orch := NewGravityOrchestrator(
-// 			zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}),
-// 			mockQClient,
-// 			gravityBroadcastClient,
-// 			gravityContract,
-// 			fromAddress,
-// 			nil,
-// 			nil,
-// 			nil,
-// 			time.Second,
-// 			time.Second,
-// 			time.Second,
-// 			100,
-// 		)
-
-// 		block, err := orch.GetLastCheckedBlock(context.Background(), 0)
-// 		assert.EqualError(t, err, "no last event response returned")
-// 		assert.Equal(t, uint64(0), block)
-// 	})
-// }
+import (
+	"context"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Gravity-Bridge/Gravity-Bridge/module/x/gravity/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum"
+	ethcmn "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/umee-network/peggo/mocks"
+	"github.com/umee-network/peggo/orchestrator/cosmos"
+	"github.com/umee-network/peggo/orchestrator/ethereum/committer"
+	gravity "github.com/umee-network/peggo/orchestrator/ethereum/gravity"
+)
+
+func TestGetLastCheckedBlock(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		logger := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr})
+		fromAddress := ethcmn.HexToAddress("0xd8da6bf26964af9d7eed9e03e53415d37aa96045")
+		gravityAddress := ethcmn.HexToAddress("0x3bdf8428734244c9e5d82c95d125081939d6d42d")
+
+		mockQClient := mocks.NewMockQueryClient(mockCtrl)
+
+		mockQClient.EXPECT().LastEventNonceByAddr(gomock.Any(), &types.QueryLastEventNonceByAddrRequest{
+			Address: sdk.AccAddress{}.String(),
+		}).Return(&types.QueryLastEventNonceByAddrResponse{
+			EventNonce: 1,
+		}, nil)
+
+		ethProvider := mocks.NewMockEVMProviderWithRet(mockCtrl)
+		ethProvider.EXPECT().PendingNonceAt(gomock.Any(), fromAddress).Return(uint64(1), nil)
+		ethProvider.EXPECT().HeaderByNumber(gomock.Any(), nil).
+			Return(&ethtypes.Header{
+				Number: big.NewInt(100),
+			}, nil)
+
+			// FilterSendToCosmosEvent
+		ethProvider.EXPECT().FilterLogs(
+			gomock.Any(),
+			MatchFilterQuery(ethereum.FilterQuery{
+				FromBlock: new(big.Int).SetUint64(0),
+				ToBlock:   new(big.Int).SetUint64(100),
+				Addresses: []ethcmn.Address{gravityAddress},
+				Topics:    [][]ethcmn.Hash{{ethcmn.HexToHash("0x9e9794dbf94b0a0aa31a480f5b38550eda7f89115ac8fbf4953fa4dd219900c9")}, {}, {}},
+			})).
+			Return(
+				[]ethtypes.Log{},
+				nil,
+			).Times(1)
+
+		// FilterERC20DeployedEvent
+		ethProvider.EXPECT().FilterLogs(
+			gomock.Any(),
+			MatchFilterQuery(ethereum.FilterQuery{
+				FromBlock: new(big.Int).SetUint64(0),
+				ToBlock:   new(big.Int).SetUint64(100),
+				Addresses: []ethcmn.Address{gravityAddress},
+				Topics:    [][]ethcmn.Hash{{ethcmn.HexToHash("0x82fe3a4fa49c6382d0c085746698ddbbafe6c2bf61285b19410644b5b26287c7")}, {}},
+			})).
+			Return(
+				[]ethtypes.Log{},
+				nil,
+			).Times(1)
+
+		// TransactionBatchExecutedEvent
+		ethProvider.EXPECT().FilterLogs(
+			gomock.Any(),
+			MatchFilterQuery(ethereum.FilterQuery{
+				FromBlock: new(big.Int).SetUint64(0),
+				ToBlock:   new(big.Int).SetUint64(100),
+				Addresses: []ethcmn.Address{gravityAddress},
+				Topics:    [][]ethcmn.Hash{{ethcmn.HexToHash("0x02c7e81975f8edb86e2a0c038b7b86a49c744236abf0f6177ff5afc6986ab708")}, {}, {}},
+			})).
+			Return(
+				[]ethtypes.Log{},
+				nil,
+			).Times(1)
+
+		// FilterValsetUpdatedEvent
+		ethProvider.EXPECT().FilterLogs(
+			gomock.Any(),
+			MatchFilterQuery(ethereum.FilterQuery{
+				FromBlock: new(big.Int).SetUint64(0),
+				ToBlock:   new(big.Int).SetUint64(100),
+				Addresses: []ethcmn.Address{gravityAddress},
+				Topics:    [][]ethcmn.Hash{{ethcmn.HexToHash("0x76d08978c024a4bf8cbb30c67fd78fcaa1827cbc533e4e175f36d07e64ccf96a")}, {}},
+			})).
+			Return(
+				[]ethtypes.Log{
+					{
+						Address:     gravityAddress,
+						Topics:      []ethcmn.Hash{ethcmn.HexToHash("0x76d08978c024a4bf8cbb30c67fd78fcaa1827cbc533e4e175f36d07e64ccf96a"), ethcmn.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000")},
+						Data:        hexutil.MustDecode("0x00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000000000000000000000000000000000000000001000000000000000000000000facf66789dd2fa6d80a36353f900922cb6d990f100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000100000000"),
+						BlockNumber: 3,
+						TxHash:      ethcmn.HexToHash("0x0"),
+						TxIndex:     2,
+						BlockHash:   ethcmn.HexToHash("0x0"),
+						Index:       1,
+						Removed:     false,
+					},
+				},
+
+				nil,
+			).Times(1)
+
+		ethGasPriceAdjustment := 1.0
+		ethCommitter, _ := committer.NewEthCommitter(
+			logger,
+			fromAddress,
+			ethGasPriceAdjustment,
+			1.0,
+			nil,
+			ethProvider,
+		)
+
+		gravityContract, _ := gravity.NewGravityContract(logger, ethCommitter, gravityAddress, nil)
+
+		mockCosmos := mocks.NewMockCosmosClient(mockCtrl)
+		mockCosmos.EXPECT().FromAddress().Return(sdk.AccAddress{}).AnyTimes()
+		mockPersonalSignFn := func(account ethcmn.Address, data []byte) (sig []byte, err error) {
+			return []byte{}, errors.New("some error during signing")
+		}
+
+		gravityBroadcastClient := cosmos.NewGravityBroadcastClient(
+			logger,
+			nil,
+			mockCosmos,
+			nil,
+			mockPersonalSignFn,
+		)
+
+		orch := NewGravityOrchestrator(
+			zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}),
+			mockQClient,
+			gravityBroadcastClient,
+			gravityContract,
+			fromAddress,
+			nil,
+			nil,
+			nil,
+			time.Second,
+			time.Second,
+			time.Second,
+			100,
+			0,
+		)
+
+		block, err := orch.GetLastCheckedBlock(context.Background(), 0)
+		assert.Nil(t, err)
+		assert.Equal(t, uint64(3), block)
+	})
+}

--- a/test/e2e/chain.go
+++ b/test/e2e/chain.go
@@ -123,14 +123,15 @@ func (c *chain) createAndInitOrchestrators(count int) error {
 		// create orchestrator
 		orchestrator := c.createOrchestrator(i)
 
-		// create keys
-		mnemonic, info, err := createMemoryKey()
+		err := orchestrator.createKey("orch")
 		if err != nil {
 			return err
 		}
 
-		orchestrator.keyInfo = *info
-		orchestrator.mnemonic = mnemonic
+		err = orchestrator.generateEthereumKey()
+		if err != nil {
+			return err
+		}
 
 		c.orchestrators = append(c.orchestrators, orchestrator)
 	}

--- a/test/e2e/docker/ganache.Dockerfile
+++ b/test/e2e/docker/ganache.Dockerfile
@@ -1,0 +1,8 @@
+# node:alpine will be our base image to create this image
+FROM node:16.13.2-alpine
+# Set the /app directory as working directory
+WORKDIR /app
+# Install ganache-cli globally
+RUN npm install -g ganache-cli
+# Set the default command for the image
+CMD ["ganache-cli", "-h", "0.0.0.0", "--networkId", "15"]

--- a/test/e2e/docker/ganache.Dockerfile
+++ b/test/e2e/docker/ganache.Dockerfile
@@ -1,8 +1,9 @@
-# node:alpine will be our base image to create this image
 FROM node:16.13.2-alpine
-# Set the /app directory as working directory
+
 WORKDIR /app
+
 # Install ganache-cli globally
 RUN npm install -g ganache-cli
+
 # Set the default command for the image
 CMD ["ganache-cli", "-h", "0.0.0.0", "--networkId", "15"]

--- a/test/e2e/e2e_setup_test.go
+++ b/test/e2e/e2e_setup_test.go
@@ -326,32 +326,6 @@ func (s *IntegrationTestSuite) initValidatorConfigs() {
 	}
 }
 
-// func (s *IntegrationTestSuite) initEthereum() {
-// 	// generate ethereum keys for validators add them to the ethereum genesis
-// 	ethGenesis := EthereumGenesis{
-// 		Difficulty: "0x400",
-// 		GasLimit:   "0xB71B00",
-// 		Config:     EthereumConfig{ChainID: ethChainID},
-// 		Alloc:      make(map[string]Allocation, len(s.chain.validators)+1),
-// 	}
-
-// 	alloc := Allocation{
-// 		Balance: "0x1337000000000000000000",
-// 	}
-
-// 	ethGenesis.Alloc["0xBf660843528035a5A4921534E156a27e64B231fE"] = alloc
-// 	for _, val := range s.chain.validators {
-// 		s.Require().NoError(val.generateEthereumKey())
-// 		ethGenesis.Alloc[val.ethereumKey.address] = alloc
-// 	}
-
-// 	ethGenBz, err := json.MarshalIndent(ethGenesis, "", "  ")
-// 	s.Require().NoError(err)
-
-// 	// write out the genesis file
-// 	s.Require().NoError(writeFile(filepath.Join(s.chain.configDir(), "eth_genesis.json"), ethGenBz))
-// }
-
 func (s *IntegrationTestSuite) runGanacheContainer() {
 	s.T().Log("starting Ganache container...")
 

--- a/test/e2e/e2e_setup_test.go
+++ b/test/e2e/e2e_setup_test.go
@@ -20,6 +20,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ory/dockertest/v3"
 	"github.com/ory/dockertest/v3/docker"
@@ -181,9 +182,9 @@ func (s *IntegrationTestSuite) initEthereum() {
 	}
 
 	ethGenesis.Alloc["0xBf660843528035a5A4921534E156a27e64B231fE"] = alloc
-	for _, val := range s.chain.validators {
-		s.Require().NoError(val.generateEthereumKey())
-		ethGenesis.Alloc[val.ethereumKey.address] = alloc
+	for _, orch := range s.chain.orchestrators {
+		s.Require().NoError(orch.generateEthereumKey())
+		ethGenesis.Alloc[orch.ethereumKey.address] = alloc
 	}
 
 	ethGenBz, err := json.MarshalIndent(ethGenesis, "", "  ")
@@ -208,15 +209,6 @@ func (s *IntegrationTestSuite) initGenesis() {
 	s.Require().NoError(cdc.UnmarshalJSON(appGenState[gravitytypes.ModuleName], &gravityGenState))
 
 	gravityGenState.Params.BridgeChainId = uint64(ethChainID)
-	gravityGenState.DelegateKeys = make([]gravitytypes.MsgSetOrchestratorAddress, len(s.chain.validators))
-
-	for i, val := range s.chain.validators {
-		gravityGenState.DelegateKeys[i] = gravitytypes.MsgSetOrchestratorAddress{
-			Validator:    sdk.ValAddress(val.keyInfo.GetAddress()).String(),
-			Orchestrator: val.keyInfo.GetAddress().String(),
-			EthAddress:   val.ethereumKey.address,
-		}
-	}
 
 	bz, err := cdc.MarshalJSON(&gravityGenState)
 	s.Require().NoError(err)
@@ -252,7 +244,10 @@ func (s *IntegrationTestSuite) initGenesis() {
 		createValmsg, err := val.buildCreateValidatorMsg(stakeAmountCoin)
 		s.Require().NoError(err)
 
-		signedTx, err := val.signMsg(createValmsg)
+		delKeysMsg, err := val.buildDelegateKeysMsg(s.chain.orchestrators[i].keyInfo.GetAddress(), s.chain.orchestrators[i].ethereumKey.address)
+		s.Require().NoError(err)
+
+		signedTx, err := val.signMsg(createValmsg, delKeysMsg)
 		s.Require().NoError(err)
 
 		txRaw, err := cdc.MarshalJSON(signedTx)
@@ -348,9 +343,9 @@ func (s *IntegrationTestSuite) runGanacheContainer() {
 	}
 
 	entrypoint = append(entrypoint, "--account", "0xb1bab011e03a9862664706fc3bbaa1b16651528e5f0e7fbfcbfdd8be302a13e7,0x3635C9ADC5DEA00000")
-	for _, val := range s.chain.validators {
-		s.Require().NoError(val.generateEthereumKey())
-		entrypoint = append(entrypoint, "--account", val.ethereumKey.privateKey+",0x3635C9ADC5DEA00000")
+	for _, orch := range s.chain.orchestrators {
+		s.Require().NoError(orch.generateEthereumKey())
+		entrypoint = append(entrypoint, "--account", orch.ethereumKey.privateKey+",0x3635C9ADC5DEA00000")
 	}
 
 	s.ethResource, err = s.dkrPool.BuildAndRunWithBuildOptions(
@@ -550,7 +545,7 @@ func (s *IntegrationTestSuite) runContractDeployment() {
 				"bridge",
 				"deploy-gravity",
 				"--eth-pk",
-				ethMinerPK[2:], // remove 0x prefix
+				ethMinerPK,
 				"--eth-rpc",
 				fmt.Sprintf("http://%s:8545", s.ethResource.Container.Name[1:]),
 				"--cosmos-grpc",
@@ -640,22 +635,19 @@ func (s *IntegrationTestSuite) runOrchestrators() {
 	s.T().Log("starting orchestrator containers...")
 
 	s.orchResources = make([]*dockertest.Resource, len(s.chain.validators))
-	for i, val := range s.chain.validators {
+	for i, orch := range s.chain.orchestrators {
 		resource, err := s.dkrPool.RunWithOptions(
 			&dockertest.RunOptions{
 				Name:       s.chain.orchestrators[i].instanceName(),
 				NetworkID:  s.dkrNet.Network.ID,
 				Repository: "umeenet/peggo",
-				Mounts: []string{
-					fmt.Sprintf("%s/:/root/.umee", val.configDir()),
-				},
 				// NOTE: container names are prefixed with '/'
 				Entrypoint: []string{
 					"peggo",
 					"orchestrator",
 					s.gravityContractAddr,
 					"--eth-pk",
-					val.ethereumKey.privateKey[2:], // remove 0x prefix
+					orch.ethereumKey.privateKey,
 					"--eth-rpc",
 					fmt.Sprintf("http://%s:8545", s.ethResource.Container.Name[1:]),
 					"--cosmos-chain-id",
@@ -667,14 +659,14 @@ func (s *IntegrationTestSuite) runOrchestrators() {
 					"--cosmos-gas-prices",
 					fmt.Sprintf("%s%s", minGasPrice, photonDenom),
 					"--cosmos-from",
-					val.keyInfo.GetName(),
-					"--cosmos-keyring-dir=/root/.umee",
-					"--cosmos-keyring=test",
+					s.chain.orchestrators[i].keyInfo.GetName(),
 					"--relay-batches=true",
 					"--relay-valsets=true",
 					"--profit-multiplier=0.0",
 					"--relayer-loop-multiplier=1.0",
 					"--requester-loop-multiplier=1.0",
+					"--cosmos-pk",
+					hexutil.Encode(s.chain.orchestrators[i].privateKey.Bytes()),
 				},
 			},
 			noRestart,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -15,7 +15,7 @@ func (s *IntegrationTestSuite) TestPhotonTokenTransfers() {
 
 	// send 100 photon tokens from Umee to Ethereum
 	s.Run("send_photon_tokens_to_eth", func() {
-		ethRecipient := s.chain.validators[1].ethereumKey.address
+		ethRecipient := s.chain.orchestrators[1].ethereumKey.address
 		s.sendFromUmeeToEth(0, ethRecipient, "100photon", "10photon", "3photon")
 
 		umeeEndpoint := fmt.Sprintf("http://%s", s.valResources[0].GetHostPort("1317/tcp"))
@@ -87,7 +87,7 @@ func (s *IntegrationTestSuite) TestUmeeTokenTransfers() {
 
 	// send 300 umee tokens from Umee to Ethereum
 	s.Run("send_uumee_tokens_to_eth", func() {
-		ethRecipient := s.chain.validators[1].ethereumKey.address
+		ethRecipient := s.chain.orchestrators[1].ethereumKey.address
 		s.sendFromUmeeToEth(0, ethRecipient, "300uumee", "10photon", "7uumee")
 
 		endpoint := fmt.Sprintf("http://%s", s.valResources[0].GetHostPort("1317/tcp"))

--- a/test/e2e/e2e_util_test.go
+++ b/test/e2e/e2e_util_test.go
@@ -40,7 +40,7 @@ func (s *IntegrationTestSuite) deployERC20Token(baseDenom string) string {
 			s.gravityContractAddr,
 			baseDenom,
 			"--eth-pk",
-			ethMinerPK[2:], // remove 0x prefix
+			ethMinerPK,
 			"--eth-rpc",
 			fmt.Sprintf("http://%s:8545", s.ethResource.Container.Name[1:]),
 			"--cosmos-chain-id",
@@ -139,8 +139,8 @@ func (s *IntegrationTestSuite) registerOrchAddresses(valIdx int, umeeFee string)
 			"gravity",
 			"set-orchestrator-address",
 			valAddr.String(),
-			valAddr.String(),
-			s.chain.validators[valIdx].ethereumKey.address,
+			s.chain.orchestrators[valIdx].keyInfo.GetAddress().String(),
+			s.chain.orchestrators[valIdx].ethereumKey.address,
 			fmt.Sprintf("--%s=%s", flags.FlagChainID, s.chain.id),
 			fmt.Sprintf("--%s=%s", flags.FlagFees, umeeFee),
 			"--keyring-backend=test",
@@ -249,7 +249,7 @@ func (s *IntegrationTestSuite) sendFromEthToUmee(valIdx int, tokenAddr, toUmeeAd
 
 	s.T().Logf(
 		"sending tokens from Ethereum to Umee; from: %s, to: %s, amount: %s, contract: %s",
-		s.chain.validators[valIdx].ethereumKey.address, toUmeeAddr, amount, tokenAddr,
+		s.chain.orchestrators[valIdx].ethereumKey.address, toUmeeAddr, amount, tokenAddr,
 	)
 
 	exec, err := s.dkrPool.Client.CreateExec(docker.CreateExecOptions{
@@ -267,7 +267,7 @@ func (s *IntegrationTestSuite) sendFromEthToUmee(valIdx int, tokenAddr, toUmeeAd
 			toUmeeAddr,
 			amount,
 			"--eth-pk",
-			s.chain.validators[valIdx].ethereumKey.privateKey[2:], // remove 0x prefix
+			s.chain.orchestrators[valIdx].ethereumKey.privateKey,
 			"--eth-rpc",
 			fmt.Sprintf("http://%s:8545", s.ethResource.Container.Name[1:]),
 			"--cosmos-chain-id",

--- a/test/e2e/orchestrator.go
+++ b/test/e2e/orchestrator.go
@@ -1,17 +1,100 @@
 package e2e
 
 import (
+	"crypto/ecdsa"
 	"fmt"
 
+	sdkcrypto "github.com/cosmos/cosmos-sdk/crypto"
+	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 type orchestrator struct {
-	index    int
-	mnemonic string
-	keyInfo  keyring.Info
+	index       int
+	mnemonic    string
+	keyInfo     keyring.Info
+	privateKey  cryptotypes.PrivKey
+	ethereumKey ethereumKey
+}
+
+type ethereumKey struct {
+	publicKey  string
+	privateKey string
+	address    string
 }
 
 func (o *orchestrator) instanceName() string {
 	return fmt.Sprintf("orchestrator%d", o.index)
+}
+
+func (o *orchestrator) generateEthereumKey() error {
+	privateKey, err := crypto.GenerateKey()
+	if err != nil {
+		return err
+	}
+
+	privateKeyBytes := crypto.FromECDSA(privateKey)
+
+	publicKey := privateKey.Public()
+	publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
+	if !ok {
+		return fmt.Errorf("unexpected public key type; expected: %T, got: %T", &ecdsa.PublicKey{}, publicKey)
+	}
+
+	publicKeyBytes := crypto.FromECDSAPub(publicKeyECDSA)
+
+	o.ethereumKey = ethereumKey{
+		privateKey: hexutil.Encode(privateKeyBytes),
+		publicKey:  hexutil.Encode(publicKeyBytes),
+		address:    crypto.PubkeyToAddress(*publicKeyECDSA).Hex(),
+	}
+
+	return nil
+}
+
+func (o *orchestrator) createKey(name string) error {
+	mnemonic, err := createMnemonic()
+	if err != nil {
+		return err
+	}
+
+	return o.createKeyFromMnemonic(name, mnemonic)
+}
+
+func (o *orchestrator) createKeyFromMnemonic(name, mnemonic string) error {
+	kb, err := keyring.New(keyringAppName, keyring.BackendMemory, "", nil)
+	if err != nil {
+		return err
+	}
+
+	keyringAlgos, _ := kb.SupportedAlgorithms()
+	algo, err := keyring.NewSigningAlgoFromString(string(hd.Secp256k1Type), keyringAlgos)
+	if err != nil {
+		return err
+	}
+
+	info, err := kb.NewAccount(name, mnemonic, "", sdk.FullFundraiserPath, algo)
+	if err != nil {
+		return err
+	}
+
+	privKeyArmor, err := kb.ExportPrivKeyArmor(name, keyringPassphrase)
+	if err != nil {
+		return err
+	}
+
+	privKey, _, err := sdkcrypto.UnarmorDecryptPrivKey(privKeyArmor, keyringPassphrase)
+	if err != nil {
+		return err
+	}
+
+	o.keyInfo = info
+	o.mnemonic = mnemonic
+	o.privateKey = privKey
+
+	return nil
 }


### PR DESCRIPTION
This PR enables the use of the flag `PEGGO_E2E_USE_GANACHE=true` to run tests against a Ganache instance instead of Geth. This allows (and encourages) devs to run the E2E locally and more often. **It shouldn't be used in the CI.**

It's basically scratching my own itch of wanting to run E2E tests as fast as possible 😄 