### PR TITLE
feat: Add flag to set the max amount of messages per cosmos transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 
-- [#132] Add `cosmos-msgs-per-tx` flag
+- [#132] Add `cosmos-msgs-per-tx` flag to set how many messages (Ethereum claims)
+  will be sent in each Cosmos transaction.
 
 ## [v0.2.0](https://github.com/umee-network/peggo/releases/tag/v0.2.0) - 2022-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Improvements
+
+- [#132] Add `cosmos-msgs-per-tx` flag
+
 ## [v0.2.0](https://github.com/umee-network/peggo/releases/tag/v0.2.0) - 2022-01-17
 
 ### Features

--- a/cmd/peggo/flags.go
+++ b/cmd/peggo/flags.go
@@ -25,6 +25,7 @@ const (
 	flagCosmosPK                = "cosmos-pk"
 	flagCosmosUseLedger         = "cosmos-use-ledger"
 	flagCosmosFeeGranter        = "cosmos-fee-granter"
+	flagCosmosMsgsPerTx         = "cosmos-msgs-per-tx"
 	flagEthKeystoreDir          = "eth-keystore-dir"
 	flagEthFrom                 = "eth-from"
 	flagEthPassphrase           = "eth-passphrase"

--- a/cmd/peggo/orchestrator.go
+++ b/cmd/peggo/orchestrator.go
@@ -144,6 +144,7 @@ func getOrchestratorCmd() *cobra.Command {
 				daemonClient,
 				signerFn,
 				personalSignFn,
+				konfig.Int(flagCosmosMsgsPerTx),
 			)
 
 			gravityAddr := ethcmn.HexToAddress(args[0])
@@ -252,6 +253,7 @@ func getOrchestratorCmd() *cobra.Command {
 	cmd.Flags().Float64(flagRequesterLoopMultiplier, 60.0, "Multiplier for the batch requester loop duration (in Cosmos blocks)")
 	cmd.Flags().String(flagCosmosFeeGranter, "", "Set an (optional) fee granter address that will pay for Cosmos fees (feegrant must exist)")
 	cmd.Flags().Int64(flagBridgeStartHeight, 0, "Set an (optional) height to wait for the bridge to be available")
+	cmd.Flags().Int(flagCosmosMsgsPerTx, 10, "Set a maximum number of messages to send per transaction (used for claims)")
 	cmd.Flags().AddFlagSet(cosmosFlagSet())
 	cmd.Flags().AddFlagSet(cosmosKeyringFlagSet())
 	cmd.Flags().AddFlagSet(ethereumKeyOptsFlagSet())

--- a/orchestrator/cosmos/broadcast_test.go
+++ b/orchestrator/cosmos/broadcast_test.go
@@ -39,6 +39,7 @@ func TestSendValsetConfirm(t *testing.T) {
 			mockCosmos,
 			nil,
 			mockPersonalSignFn,
+			10,
 		)
 
 		err := s.SendValsetConfirm(context.Background(), ethcmn.Address{}, "", types.Valset{
@@ -64,6 +65,7 @@ func TestSendValsetConfirm(t *testing.T) {
 			mockCosmos,
 			nil,
 			mockPersonalSignFn,
+			10,
 		)
 
 		err := s.SendValsetConfirm(context.Background(), ethcmn.Address{}, "", types.Valset{
@@ -91,6 +93,7 @@ func TestSendValsetConfirm(t *testing.T) {
 			mockCosmos,
 			nil,
 			mockPersonalSignFn,
+			10,
 		)
 
 		err := s.SendValsetConfirm(context.Background(), ethcmn.Address{}, "", types.Valset{
@@ -122,6 +125,7 @@ func TestSendBatchConfirm(t *testing.T) {
 			mockCosmos,
 			nil,
 			mockPersonalSignFn,
+			10,
 		)
 
 		err := s.SendBatchConfirm(context.Background(), ethcmn.Address{}, "", types.OutgoingTxBatch{})
@@ -145,6 +149,7 @@ func TestSendBatchConfirm(t *testing.T) {
 			mockCosmos,
 			nil,
 			mockPersonalSignFn,
+			10,
 		)
 
 		err := s.SendBatchConfirm(context.Background(), ethcmn.Address{}, "", types.OutgoingTxBatch{})
@@ -170,6 +175,7 @@ func TestSendBatchConfirm(t *testing.T) {
 			mockCosmos,
 			nil,
 			mockPersonalSignFn,
+			10,
 		)
 
 		err := s.SendBatchConfirm(context.Background(), ethcmn.Address{}, "", types.OutgoingTxBatch{})
@@ -246,6 +252,7 @@ func TestSendEthereumClaims(t *testing.T) {
 		mockCosmos,
 		nil,
 		nil,
+		10,
 	)
 
 	deposits := []*wrappers.GravitySendToCosmosEvent{
@@ -316,6 +323,7 @@ func TestSendEthereumClaimsIgnoreNonSequentialNonces(t *testing.T) {
 	s := gravityBroadcastClient{
 		daemonQueryClient: nil,
 		broadcastClient:   mockCosmos,
+		msgsPerTx:         10,
 	}
 
 	// We have events with nonces 1, 2, 3, 4, 5, 6, 7, 9.
@@ -392,6 +400,7 @@ func TestSendRequestBatch(t *testing.T) {
 			mockCosmos,
 			nil,
 			nil,
+			10,
 		)
 
 		err := s.SendRequestBatch(context.Background(), "uumee")
@@ -413,6 +422,7 @@ func TestSendRequestBatch(t *testing.T) {
 			mockCosmos,
 			nil,
 			nil,
+			10,
 		)
 
 		err := s.SendRequestBatch(context.Background(), "uumee")

--- a/orchestrator/eth_event_watcher_test.go
+++ b/orchestrator/eth_event_watcher_test.go
@@ -139,6 +139,7 @@ func TestCheckForEvents(t *testing.T) {
 			mockCosmos,
 			nil,
 			mockPersonalSignFn,
+			10,
 		)
 
 		mockQClient := mocks.NewMockQueryClient(mockCtrl)
@@ -223,6 +224,7 @@ func TestCheckForEvents(t *testing.T) {
 			mockCosmos,
 			nil,
 			mockPersonalSignFn,
+			10,
 		)
 
 		mockQClient := mocks.NewMockQueryClient(mockCtrl)
@@ -330,6 +332,7 @@ func TestCheckForEvents(t *testing.T) {
 			mockCosmos,
 			nil,
 			mockPersonalSignFn,
+			10,
 		)
 
 		mockQClient := mocks.NewMockQueryClient(mockCtrl)
@@ -450,6 +453,7 @@ func TestCheckForEvents(t *testing.T) {
 			mockCosmos,
 			nil,
 			mockPersonalSignFn,
+			10,
 		)
 
 		mockQClient := mocks.NewMockQueryClient(mockCtrl)
@@ -584,6 +588,7 @@ func TestCheckForEvents(t *testing.T) {
 			mockCosmos,
 			nil,
 			mockPersonalSignFn,
+			10,
 		)
 
 		mockQClient := mocks.NewMockQueryClient(mockCtrl)

--- a/orchestrator/oracle_resync_test.go
+++ b/orchestrator/oracle_resync_test.go
@@ -140,6 +140,7 @@ func TestGetLastCheckedBlock(t *testing.T) {
 			mockCosmos,
 			nil,
 			mockPersonalSignFn,
+			10,
 		)
 
 		orch := NewGravityOrchestrator(


### PR DESCRIPTION
After giving this more thought, I think we need to make this configurable. Given that network conditions are always changing, we should provide a way for orchestrators to modify this in order to stay as close as possible to the nonce in the Ethereum contract.
The main example I can think of is that orchestrators should be able to send more msgs per tx during low traffic times in case they were left a bit behind; or in case a new validator wants to join.
Remember that if ~33% of orchestrators are behind, txs going from Eth to Umee will get delayed.

So, I would say that we should use a sane default but remove the hard limit and allow orchestrators to set their own value.

Added flag: `--cosmos-msgs-per-tx` with a default value of 10.

Closes: #109 