### PR TITLE
feat: Add token addresses fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Improvements
+
+- [#172] Add fallback token addresses (to aid price lookup)
+
 ## [v0.2.3](https://github.com/umee-network/peggo/releases/tag/v0.2.3) - 2022-02-07
 
 ### Improvements

--- a/orchestrator/coingecko/coingecko.go
+++ b/orchestrator/coingecko/coingecko.go
@@ -85,7 +85,7 @@ func (cp *PriceFeed) QueryUSDPriceByCoinID(coinID string) (float64, error) {
 	price := respBody[coinID].USD
 
 	if price == zeroPrice {
-		return zeroPrice, errors.Errorf("failed to get price for " + coinID)
+		return zeroPrice, errors.Errorf("failed to get price for %s", coinID)
 	}
 
 	return price, nil

--- a/orchestrator/coingecko/coingecko.go
+++ b/orchestrator/coingecko/coingecko.go
@@ -92,7 +92,6 @@ func (cp *PriceFeed) QueryUSDPriceByCoinID(coinID string) (float64, error) {
 }
 
 func (cp *PriceFeed) QueryTokenUSDPrice(erc20Contract ethcmn.Address) (float64, error) {
-
 	// If the token is one of the deployed by the Gravity contract, use the
 	// stored coin ID to look up the price.
 	if coinID, ok := bridgeTokensCoinIDs[erc20Contract.Hex()]; ok {

--- a/orchestrator/coingecko/coingecko.go
+++ b/orchestrator/coingecko/coingecko.go
@@ -2,11 +2,11 @@ package coingecko
 
 import (
 	"encoding/json"
+	"strings"
 
 	"net/http"
 	"net/url"
 	"path"
-	"strings"
 	"time"
 
 	ethcmn "github.com/ethereum/go-ethereum/common"
@@ -48,7 +48,7 @@ type priceResponse map[string]struct {
 	USD float64 `json:"usd"`
 }
 
-func (cp *PriceFeed) QueryETHUSDPrice() (float64, error) {
+func (cp *PriceFeed) QueryUSDPriceByCoinID(coinID string) (float64, error) {
 	u, err := url.ParseRequestURI(urlJoin(cp.config.BaseURL, "simple", "price"))
 	if err != nil {
 		cp.logger.Fatal().Err(err).Msg("failed to parse URL")
@@ -56,7 +56,7 @@ func (cp *PriceFeed) QueryETHUSDPrice() (float64, error) {
 
 	q := make(url.Values)
 
-	q.Set("ids", "ethereum")
+	q.Set("ids", coinID)
 	q.Set("vs_currencies", "usd")
 	u.RawQuery = q.Encode()
 
@@ -82,16 +82,22 @@ func (cp *PriceFeed) QueryETHUSDPrice() (float64, error) {
 		return zeroPrice, errors.Wrapf(err, "failed to parse response body from %s", reqURL)
 	}
 
-	price := respBody["ethereum"].USD
+	price := respBody[coinID].USD
 
 	if price == zeroPrice {
-		return zeroPrice, errors.Errorf("failed to get price for Ethereum")
+		return zeroPrice, errors.Errorf("failed to get price for " + coinID)
 	}
 
 	return price, nil
 }
 
-func (cp *PriceFeed) QueryUSDPrice(erc20Contract ethcmn.Address) (float64, error) {
+func (cp *PriceFeed) QueryTokenUSDPrice(erc20Contract ethcmn.Address) (float64, error) {
+
+	// If the token is one of the deployed by the Gravity contract, use the
+	// stored coin ID to look up the price.
+	if coinID, ok := bridgeTokensCoinIDs[erc20Contract.Hex()]; ok {
+		return cp.QueryUSDPriceByCoinID(coinID)
+	}
 
 	u, err := url.ParseRequestURI(urlJoin(cp.config.BaseURL, "simple", "token_price", "ethereum"))
 	if err != nil {

--- a/orchestrator/coingecko/coingecko_test.go
+++ b/orchestrator/coingecko/coingecko_test.go
@@ -14,7 +14,7 @@ import (
 
 var logger = zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}).Level(zerolog.DebugLevel).With().Timestamp().Logger()
 
-func TestQueryETHUSDPrice(t *testing.T) {
+func TestQueryUSDPriceByCoinID(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 
 		expected := `{"ethereum": {"usd": 4271.57}}`
@@ -24,7 +24,7 @@ func TestQueryETHUSDPrice(t *testing.T) {
 		defer svr.Close()
 		coingeckoFeed := NewCoingeckoPriceFeed(logger, 100, &Config{BaseURL: svr.URL})
 
-		price, err := coingeckoFeed.QueryETHUSDPrice()
+		price, err := coingeckoFeed.QueryUSDPriceByCoinID("ethereum")
 		assert.NoError(t, err)
 		assert.Equal(t, 4271.57, price)
 	})
@@ -36,7 +36,7 @@ func TestQueryETHUSDPrice(t *testing.T) {
 		defer svr.Close()
 		coingeckoFeed := NewCoingeckoPriceFeed(logger, 100, &Config{BaseURL: svr.URL})
 
-		_, err := coingeckoFeed.QueryETHUSDPrice()
+		_, err := coingeckoFeed.QueryUSDPriceByCoinID("ethereum")
 		assert.EqualError(t, err, "failed to parse response body from "+svr.URL+"/simple/price?ids=ethereum&vs_currencies=usd: EOF")
 	})
 
@@ -49,13 +49,13 @@ func TestQueryETHUSDPrice(t *testing.T) {
 		defer svr.Close()
 		coingeckoFeed := NewCoingeckoPriceFeed(logger, 100, &Config{BaseURL: svr.URL})
 
-		price, err := coingeckoFeed.QueryETHUSDPrice()
-		assert.EqualError(t, err, "failed to get price for Ethereum")
+		price, err := coingeckoFeed.QueryUSDPriceByCoinID("ethereum")
+		assert.EqualError(t, err, "failed to get price for ethereum")
 		assert.Equal(t, 0.0, price)
 	})
 }
 
-func TestQueryUSDPrice(t *testing.T) {
+func TestQueryTokenUSDPrice(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		expected := `{"0xdac17f958d2ee523a2206206994597c13d831ec7":{"usd":0.998233}}`
 		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -64,7 +64,7 @@ func TestQueryUSDPrice(t *testing.T) {
 		defer svr.Close()
 		coingeckoFeed := NewCoingeckoPriceFeed(logger, 100, &Config{BaseURL: svr.URL})
 
-		price, err := coingeckoFeed.QueryUSDPrice(ethcmn.HexToAddress("0xdac17f958d2ee523a2206206994597c13d831ec7"))
+		price, err := coingeckoFeed.QueryTokenUSDPrice(ethcmn.HexToAddress("0xdac17f958d2ee523a2206206994597c13d831ec7"))
 		assert.NoError(t, err)
 		assert.Equal(t, 0.998233, price)
 	})
@@ -76,7 +76,7 @@ func TestQueryUSDPrice(t *testing.T) {
 		defer svr.Close()
 		coingeckoFeed := NewCoingeckoPriceFeed(logger, 100, &Config{BaseURL: svr.URL})
 
-		_, err := coingeckoFeed.QueryUSDPrice(ethcmn.HexToAddress("0xdac17f958d2ee523a2206206994597c13d831ec7"))
+		_, err := coingeckoFeed.QueryTokenUSDPrice(ethcmn.HexToAddress("0xdac17f958d2ee523a2206206994597c13d831ec7"))
 		assert.EqualError(t, err, "failed to parse response body from "+svr.URL+"/simple/token_price/ethereum?contract_addresses=0xdac17f958d2ee523a2206206994597c13d831ec7&vs_currencies=usd: EOF")
 	})
 
@@ -88,7 +88,7 @@ func TestQueryUSDPrice(t *testing.T) {
 		defer svr.Close()
 		coingeckoFeed := NewCoingeckoPriceFeed(logger, 100, &Config{BaseURL: svr.URL})
 
-		price, err := coingeckoFeed.QueryUSDPrice(ethcmn.HexToAddress("0xdac17f958d2ee523a2206206994597c13d831ec7"))
+		price, err := coingeckoFeed.QueryTokenUSDPrice(ethcmn.HexToAddress("0xdac17f958d2ee523a2206206994597c13d831ec7"))
 		assert.EqualError(t, err, "failed to get price for token 0xdAC17F958D2ee523a2206206994597C13D831ec7")
 		assert.Equal(t, 0.0, price)
 	})

--- a/orchestrator/coingecko/constants.go
+++ b/orchestrator/coingecko/constants.go
@@ -1,0 +1,7 @@
+package coingecko
+
+// Everytime a new ERC20 is deployed in the Gravity Bridge contract, we need to
+// add it here and make a new release of Peggo.
+var bridgeTokensCoinIDs = map[string]string{
+	"0x0000000000000000000000000000000000000000": "eth",
+}

--- a/orchestrator/relayer/batch_relaying.go
+++ b/orchestrator/relayer/batch_relaying.go
@@ -220,7 +220,7 @@ func (s *gravityRelayer) IsBatchProfitable(
 	}
 
 	// First we get the cost of the transaction in USD
-	usdEthPrice, err := s.priceFeeder.QueryETHUSDPrice()
+	usdEthPrice, err := s.priceFeeder.QueryUSDPriceByCoinID("ethereum")
 	if err != nil {
 		s.logger.Err(err).Msg("failed to get ETH price")
 		return false
@@ -247,7 +247,7 @@ func (s *gravityRelayer) IsBatchProfitable(
 		Str("token_contract", batch.TokenContract).
 		Msg("got token decimals")
 
-	usdTokenPrice, err := s.priceFeeder.QueryUSDPrice(ethcmn.HexToAddress(batch.TokenContract))
+	usdTokenPrice, err := s.priceFeeder.QueryTokenUSDPrice(ethcmn.HexToAddress(batch.TokenContract))
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
# Why?

New ERC20 tokens deployed by our Gravity contract won't be listed for an unknown time in any price tracker. For example, Gravity Bridge's NYM ERC20 isn't listed either on Coingecko nor Uniswap.

# How?

We keep a list of the ERC20 tokens that we've deployed and their matching underlying asset. We'll have to keep this list updated every time we deploy a new ERC20.

```
var bridgeTokensCoinIDs = map[string]string{
	"0x0000000000000000000000000000000000000001": "atom",
	"0x0000000000000000000000000000000000000002": "osmo",
	"0x0000000000000000000000000000000000000003": "juno",
}
```