### PR TITLE
fix: warn user when using unencrypted non-local urls

### DIFF
--- a/cmd/peggo/bridge.go
+++ b/cmd/peggo/bridge.go
@@ -72,8 +72,13 @@ func deployGravityCmd() *cobra.Command {
 				return err
 			}
 
-			tmRPCEndpoint := konfig.String(flagTendermintRPC)
-			cosmosGRPC := konfig.String(flagCosmosGRPC)
+			logger, err := getLogger(cmd)
+			if err != nil {
+				return err
+			}
+
+			tmRPCEndpoint := parseURL(logger, konfig, flagTendermintRPC)
+			cosmosGRPC := parseURL(logger, konfig, flagCosmosGRPC)
 
 			tmRPC, err := rpchttp.New(tmRPCEndpoint, "/websocket")
 			if err != nil {
@@ -82,11 +87,6 @@ func deployGravityCmd() *cobra.Command {
 
 			fmt.Fprintf(os.Stderr, "Connected to Tendermint RPC: %s\n", tmRPCEndpoint)
 			clientCtx = clientCtx.WithClient(tmRPC).WithNodeURI(tmRPCEndpoint)
-
-			logger, err := getLogger(cmd)
-			if err != nil {
-				return err
-			}
 
 			daemonClient, err := client.NewCosmosClient(clientCtx, logger, cosmosGRPC)
 			if err != nil {
@@ -212,8 +212,13 @@ func deployERC20Cmd() *cobra.Command {
 				return err
 			}
 
-			tmRPCEndpoint := konfig.String(flagTendermintRPC)
-			cosmosGRPC := konfig.String(flagCosmosGRPC)
+			logger, err := getLogger(cmd)
+			if err != nil {
+				return err
+			}
+
+			tmRPCEndpoint := parseURL(logger, konfig, flagTendermintRPC)
+			cosmosGRPC := parseURL(logger, konfig, flagCosmosGRPC)
 
 			tmRPC, err := rpchttp.New(tmRPCEndpoint, "/websocket")
 			if err != nil {
@@ -222,11 +227,6 @@ func deployERC20Cmd() *cobra.Command {
 
 			fmt.Fprintf(os.Stderr, "Connected to Tendermint RPC: %s\n", tmRPCEndpoint)
 			clientCtx = clientCtx.WithClient(tmRPC).WithNodeURI(tmRPCEndpoint)
-
-			logger, err := getLogger(cmd)
-			if err != nil {
-				return err
-			}
 
 			daemonClient, err := client.NewCosmosClient(clientCtx, logger, cosmosGRPC)
 			if err != nil {

--- a/cmd/peggo/bridge.go
+++ b/cmd/peggo/bridge.go
@@ -77,8 +77,14 @@ func deployGravityCmd() *cobra.Command {
 				return err
 			}
 
-			tmRPCEndpoint := parseURL(logger, konfig, flagTendermintRPC)
-			cosmosGRPC := parseURL(logger, konfig, flagCosmosGRPC)
+			tmRPCEndpoint, err := parseURL(logger, konfig, flagTendermintRPC)
+			if err != nil {
+				return err
+			}
+			cosmosGRPC, err := parseURL(logger, konfig, flagCosmosGRPC)
+			if err != nil {
+				return err
+			}
 
 			tmRPC, err := rpchttp.New(tmRPCEndpoint, "/websocket")
 			if err != nil {
@@ -217,8 +223,14 @@ func deployERC20Cmd() *cobra.Command {
 				return err
 			}
 
-			tmRPCEndpoint := parseURL(logger, konfig, flagTendermintRPC)
-			cosmosGRPC := parseURL(logger, konfig, flagCosmosGRPC)
+			tmRPCEndpoint, err := parseURL(logger, konfig, flagTendermintRPC)
+			if err != nil {
+				return err
+			}
+			cosmosGRPC, err := parseURL(logger, konfig, flagCosmosGRPC)
+			if err != nil {
+				return err
+			}
 
 			tmRPC, err := rpchttp.New(tmRPCEndpoint, "/websocket")
 			if err != nil {

--- a/cmd/peggo/flags.go
+++ b/cmd/peggo/flags.go
@@ -2,6 +2,7 @@
 package peggo
 
 import (
+	"net/url"
 	"strings"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
@@ -111,10 +112,14 @@ func bridgeFlagSet() *pflag.FlagSet {
 // parseURL logs a warning if the flag provided is an
 // unencrypted non-local string, and returns the value.
 // Ref: https://github.com/umee-network/peggo/issues/178
-func parseURL(logger zerolog.Logger, konfig *koanf.Koanf, flag string) string {
+func parseURL(logger zerolog.Logger, konfig *koanf.Koanf, flag string) (string, error) {
 	endpoint := konfig.String(flag)
-	if strings.Contains(endpoint, "http://") && !strings.Contains(endpoint, "localhost") {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", err
+	}
+	if strings.EqualFold(u.Scheme, "http") && !strings.Contains(u.Host, "localhost") {
 		logger.Warn().Str(flag, endpoint).Msg("flag is unsafe; unencrypted non-local url used")
 	}
-	return endpoint
+	return endpoint, nil
 }

--- a/cmd/peggo/flags.go
+++ b/cmd/peggo/flags.go
@@ -2,7 +2,11 @@
 package peggo
 
 import (
+	"strings"
+
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/knadh/koanf"
+	"github.com/rs/zerolog"
 	"github.com/spf13/pflag"
 )
 
@@ -102,4 +106,15 @@ func bridgeFlagSet() *pflag.FlagSet {
 	fs.Int64(flagEthGasLimit, 6000000, "The Ethereum gas limit to include in the transaction")
 
 	return fs
+}
+
+// parseURL logs a warning if the flag provided is an
+// unencrypted non-local string, and returns the value.
+// Ref: https://github.com/umee-network/peggo/issues/178
+func parseURL(logger zerolog.Logger, konfig *koanf.Koanf, flag string) string {
+	endpoint := konfig.String(flag)
+	if strings.Contains(endpoint, "http://") && !strings.Contains(endpoint, "localhost") {
+		logger.Warn().Str(flag, endpoint).Msg("flag is unsafe; unencrypted non-local url used")
+	}
+	return endpoint
 }

--- a/cmd/peggo/orchestrator.go
+++ b/cmd/peggo/orchestrator.go
@@ -63,8 +63,8 @@ func getOrchestratorCmd() *cobra.Command {
 				return err
 			}
 
-			tmRPCEndpoint := konfig.String(flagTendermintRPC)
-			cosmosGRPC := konfig.String(flagCosmosGRPC)
+			tmRPCEndpoint := parseURL(logger, konfig, flagTendermintRPC)
+			cosmosGRPC := parseURL(logger, konfig, flagCosmosGRPC)
 			cosmosGasPrices := konfig.String(flagCosmosGasPrices)
 
 			tmRPC, err := rpchttp.New(tmRPCEndpoint, "/websocket")
@@ -269,7 +269,7 @@ func getOrchestratorCmd() *cobra.Command {
 }
 
 func trapSignal(cancel context.CancelFunc) {
-	var sigCh = make(chan os.Signal, 1)
+	sigCh := make(chan os.Signal, 1)
 
 	signal.Notify(sigCh, syscall.SIGTERM)
 	signal.Notify(sigCh, syscall.SIGINT)

--- a/cmd/peggo/orchestrator.go
+++ b/cmd/peggo/orchestrator.go
@@ -63,8 +63,15 @@ func getOrchestratorCmd() *cobra.Command {
 				return err
 			}
 
-			tmRPCEndpoint := parseURL(logger, konfig, flagTendermintRPC)
-			cosmosGRPC := parseURL(logger, konfig, flagCosmosGRPC)
+			tmRPCEndpoint, err := parseURL(logger, konfig, flagTendermintRPC)
+			if err != nil {
+				return err
+			}
+			cosmosGRPC, err := parseURL(logger, konfig, flagCosmosGRPC)
+			if err != nil {
+				return err
+			}
+
 			cosmosGasPrices := konfig.String(flagCosmosGasPrices)
 
 			tmRPC, err := rpchttp.New(tmRPCEndpoint, "/websocket")


### PR DESCRIPTION
Adds a log warning whenever unencrypted non-local urls are used in flags. Since it uses `url.Parse`, it should also give an error if unable to parse the url. 

Closes : #178