### PR TITLE
feat: support multiple ethereum grpc endpoints

### DIFF
--- a/cmd/peggo/bridge.go
+++ b/cmd/peggo/bridge.go
@@ -114,7 +114,7 @@ func deployGravityCmd() *cobra.Command {
 
 			// ETH RPC
 			InitEthRPCManager(konfig)
-			ethRPC, err := ethManager.GetClient()
+			ethRPC, err := ethManager.GetEthClient()
 			if err != nil {
 				return err
 			}
@@ -195,7 +195,7 @@ func deployERC20Cmd() *cobra.Command {
 			}
 
 			InitEthRPCManager(konfig)
-			ethRPC, err := ethManager.GetClient()
+			ethRPC, err := ethManager.GetEthClient()
 
 			auth, err := buildTransactOpts(konfig, ethRPC)
 			if err != nil {
@@ -327,7 +327,7 @@ network starting.`,
 			}
 
 			InitEthRPCManager(konfig)
-			ethRPC, err := ethManager.GetClient()
+			ethRPC, err := ethManager.GetEthClient()
 
 			auth, err := buildTransactOpts(konfig, ethRPC)
 			if err != nil {
@@ -386,7 +386,7 @@ func sendToCosmosCmd() *cobra.Command {
 			}
 
 			InitEthRPCManager(konfig)
-			ethRPC, err := ethManager.GetClient()
+			ethRPC, err := ethManager.GetEthClient()
 
 			gravityAddr := args[0]
 

--- a/cmd/peggo/bridge.go
+++ b/cmd/peggo/bridge.go
@@ -202,6 +202,9 @@ func deployERC20Cmd() *cobra.Command {
 
 			InitEthRPCManager(konfig)
 			ethRPC, err := ethManager.GetEthClient()
+			if err != nil {
+				return err
+			}
 
 			auth, err := buildTransactOpts(konfig)
 			if err != nil {
@@ -340,6 +343,9 @@ network starting.`,
 
 			InitEthRPCManager(konfig)
 			ethRPC, err := ethManager.GetEthClient()
+			if err != nil {
+				return err
+			}
 
 			auth, err := buildTransactOpts(konfig)
 			if err != nil {
@@ -399,6 +405,9 @@ func sendToCosmosCmd() *cobra.Command {
 
 			InitEthRPCManager(konfig)
 			ethRPC, err := ethManager.GetEthClient()
+			if err != nil {
+				return err
+			}
 
 			gravityAddr := args[0]
 

--- a/cmd/peggo/bridge.go
+++ b/cmd/peggo/bridge.go
@@ -113,10 +113,9 @@ func deployGravityCmd() *cobra.Command {
 			}
 
 			// ETH RPC
-			ethRPCEndpoint := konfig.String(flagEthRPC)
-			ethRPC, err := ethclient.Dial(ethRPCEndpoint)
+			ethRPC, err := getEthClient(konfig)
 			if err != nil {
-				return fmt.Errorf("failed to dial Ethereum RPC node: %w", err)
+				return err
 			}
 
 			auth, err := buildTransactOpts(konfig, ethRPC)
@@ -194,10 +193,9 @@ func deployERC20Cmd() *cobra.Command {
 				return err
 			}
 
-			ethRPCEndpoint := konfig.String(flagEthRPC)
-			ethRPC, err := ethclient.Dial(ethRPCEndpoint)
+			ethRPC, err := getEthClient(konfig)
 			if err != nil {
-				return fmt.Errorf("failed to dial Ethereum RPC node: %w", err)
+				return err
 			}
 
 			auth, err := buildTransactOpts(konfig, ethRPC)
@@ -329,10 +327,9 @@ network starting.`,
 				return err
 			}
 
-			ethRPCEndpoint := konfig.String(flagEthRPC)
-			ethRPC, err := ethclient.Dial(ethRPCEndpoint)
+			ethRPC, err := getEthClient(konfig)
 			if err != nil {
-				return fmt.Errorf("failed to dial Ethereum RPC node: %w", err)
+				return err
 			}
 
 			auth, err := buildTransactOpts(konfig, ethRPC)
@@ -391,10 +388,9 @@ func sendToCosmosCmd() *cobra.Command {
 				return err
 			}
 
-			ethRPCEndpoint := konfig.String(flagEthRPC)
-			ethRPC, err := ethclient.Dial(ethRPCEndpoint)
+			ethRPC, err := getEthClient(konfig)
 			if err != nil {
-				return fmt.Errorf("failed to dial Ethereum RPC node: %w", err)
+				return err
 			}
 
 			gravityAddr := args[0]

--- a/cmd/peggo/bridge.go
+++ b/cmd/peggo/bridge.go
@@ -125,7 +125,7 @@ func deployGravityCmd() *cobra.Command {
 				return err
 			}
 
-			auth, err := buildTransactOpts(konfig, ethRPC)
+			auth, err := buildTransactOpts(konfig)
 			if err != nil {
 				return err
 			}
@@ -203,7 +203,7 @@ func deployERC20Cmd() *cobra.Command {
 			InitEthRPCManager(konfig)
 			ethRPC, err := ethManager.GetEthClient()
 
-			auth, err := buildTransactOpts(konfig, ethRPC)
+			auth, err := buildTransactOpts(konfig)
 			if err != nil {
 				return err
 			}
@@ -341,7 +341,7 @@ network starting.`,
 			InitEthRPCManager(konfig)
 			ethRPC, err := ethManager.GetEthClient()
 
-			auth, err := buildTransactOpts(konfig, ethRPC)
+			auth, err := buildTransactOpts(konfig)
 			if err != nil {
 				return err
 			}
@@ -416,7 +416,7 @@ func sendToCosmosCmd() *cobra.Command {
 				}
 			}
 
-			auth, err := buildTransactOpts(konfig, ethRPC)
+			auth, err := buildTransactOpts(konfig)
 			if err != nil {
 				return err
 			}
@@ -459,7 +459,9 @@ Transaction: %s
 	return cmd
 }
 
-func buildTransactOpts(konfig *koanf.Koanf, ethClient *ethclient.Client) (*bind.TransactOpts, error) {
+func buildTransactOpts(konfig *koanf.Koanf) (*bind.TransactOpts, error) {
+	InitEthRPCManager(konfig)
+
 	ethPrivKeyHexStr := konfig.String(flagEthPK)
 
 	privKey, err := ethcrypto.ToECDSA(ethcmn.FromHex(ethPrivKeyHexStr))
@@ -478,7 +480,7 @@ func buildTransactOpts(konfig *koanf.Koanf, ethClient *ethclient.Client) (*bind.
 
 	fromAddress := ethcrypto.PubkeyToAddress(*publicKeyECDSA)
 
-	nonce, err := ethClient.PendingNonceAt(goCtx, fromAddress)
+	nonce, err := ethManager.PendingNonceAt(goCtx, fromAddress)
 	if err != nil {
 		return nil, err
 	}
@@ -486,7 +488,7 @@ func buildTransactOpts(konfig *koanf.Koanf, ethClient *ethclient.Client) (*bind.
 	goCtx, cancel = context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	ethChainID, err := ethClient.ChainID(goCtx)
+	ethChainID, err := ethManager.ChainID(goCtx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Ethereum chain ID: %w", err)
 	}
@@ -507,7 +509,7 @@ func buildTransactOpts(konfig *koanf.Koanf, ethClient *ethclient.Client) (*bind.
 		gasPrice = big.NewInt(gasPriceInt)
 
 	default:
-		gasPrice, err = ethClient.SuggestGasPrice(context.Background())
+		gasPrice, err = ethManager.SuggestGasPrice(context.Background())
 		if err != nil {
 			return nil, fmt.Errorf("failed to get Ethereum gas estimate: %w", err)
 		}
@@ -555,7 +557,7 @@ func approveERC20(konfig *koanf.Koanf, ethRPC *ethclient.Client, erc20AddrStr, g
 		return fmt.Errorf("failed to create ERC20 contract instance: %w", err)
 	}
 
-	auth, err := buildTransactOpts(konfig, ethRPC)
+	auth, err := buildTransactOpts(konfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/peggo/bridge.go
+++ b/cmd/peggo/bridge.go
@@ -113,7 +113,8 @@ func deployGravityCmd() *cobra.Command {
 			}
 
 			// ETH RPC
-			ethRPC, err := getEthClient(konfig)
+			InitEthRPCManager(konfig)
+			ethRPC, err := ethManager.GetClient()
 			if err != nil {
 				return err
 			}
@@ -193,10 +194,8 @@ func deployERC20Cmd() *cobra.Command {
 				return err
 			}
 
-			ethRPC, err := getEthClient(konfig)
-			if err != nil {
-				return err
-			}
+			InitEthRPCManager(konfig)
+			ethRPC, err := ethManager.GetClient()
 
 			auth, err := buildTransactOpts(konfig, ethRPC)
 			if err != nil {
@@ -327,10 +326,8 @@ network starting.`,
 				return err
 			}
 
-			ethRPC, err := getEthClient(konfig)
-			if err != nil {
-				return err
-			}
+			InitEthRPCManager(konfig)
+			ethRPC, err := ethManager.GetClient()
 
 			auth, err := buildTransactOpts(konfig, ethRPC)
 			if err != nil {
@@ -388,10 +385,8 @@ func sendToCosmosCmd() *cobra.Command {
 				return err
 			}
 
-			ethRPC, err := getEthClient(konfig)
-			if err != nil {
-				return err
-			}
+			InitEthRPCManager(konfig)
+			ethRPC, err := ethManager.GetClient()
 
 			gravityAddr := args[0]
 

--- a/cmd/peggo/flags.go
+++ b/cmd/peggo/flags.go
@@ -91,6 +91,7 @@ func ethereumOptsFlagSet() *pflag.FlagSet {
 	fs := pflag.NewFlagSet("", pflag.ContinueOnError)
 
 	fs.String(flagEthRPC, "http://localhost:8545", "Specify the RPC address of an Ethereum node")
+	fs.StringSlice(flagEthRPCs, []string{"http://localhost:8545"}, "Specify RPC addresses of one or more Ethereum nodes")
 	fs.Float64(flagEthGasAdjustment, float64(1.3), "Specify a gas price adjustment for Ethereum transactions")
 	fs.Float64(flagEthGasLimitAdjustment, float64(1.2), "Specify a gas limit adjustment for Ethereum transactions")
 	_ = fs.MarkDeprecated(flagEthRPC, fmt.Sprintf("Use the '%s' flag instead to provide one or more Ethereum RPC instances", flagEthRPCs))
@@ -102,8 +103,10 @@ func bridgeFlagSet() *pflag.FlagSet {
 	fs := pflag.NewFlagSet("", pflag.ContinueOnError)
 
 	fs.String(flagEthRPC, "http://localhost:8545", "Specify the RPC address of an Ethereum node")
+	fs.StringSlice(flagEthRPCs, []string{"http://localhost:8545"}, "Specify RPC addresses of one or more Ethereum nodes")
 	fs.Int64(flagEthGasPrice, 0, "The Ethereum gas price to include in the transaction; If zero, gas price will be estimated")
 	fs.Int64(flagEthGasLimit, 6000000, "The Ethereum gas limit to include in the transaction")
+	_ = fs.MarkDeprecated(flagEthRPC, fmt.Sprintf("Use the '%s' flag instead to provide one or more Ethereum RPC instances", flagEthRPCs))
 
 	return fs
 }

--- a/cmd/peggo/flags.go
+++ b/cmd/peggo/flags.go
@@ -2,6 +2,8 @@
 package peggo
 
 import (
+	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/spf13/pflag"
 )
@@ -32,6 +34,7 @@ const (
 	flagEthPK                   = "eth-pk"
 	flagEthUseLedger            = "eth-use-ledger"
 	flagEthRPC                  = "eth-rpc"
+	flagEthRPCs                 = "eth-rpcs"
 	flagEthGasAdjustment        = "eth-gas-price-adjustment"
 	flagEthGasLimitAdjustment   = "eth-gas-limit-adjustment"
 	flagEthAlchemyWS            = "eth-alchemy-ws"
@@ -93,6 +96,7 @@ func ethereumOptsFlagSet() *pflag.FlagSet {
 	fs.String(flagEthRPC, "http://localhost:8545", "Specify the RPC address of an Ethereum node")
 	fs.Float64(flagEthGasAdjustment, float64(1.3), "Specify a gas price adjustment for Ethereum transactions")
 	fs.Float64(flagEthGasLimitAdjustment, float64(1.2), "Specify a gas limit adjustment for Ethereum transactions")
+	_ = fs.MarkDeprecated(flagEthRPC, fmt.Sprintf("Use the '%s' flag instead to provide one or more Ethereum RPC instances", flagEthRPCs))
 
 	return fs
 }

--- a/cmd/peggo/flags.go
+++ b/cmd/peggo/flags.go
@@ -107,7 +107,7 @@ func bridgeFlagSet() *pflag.FlagSet {
 	fs := pflag.NewFlagSet("", pflag.ContinueOnError)
 
 	fs.String(flagEthRPC, "http://localhost:8545", "Specify the RPC address of an Ethereum node")
-	fs.StringSlice(flagEthRPCs, []string{"http://localhost:8545"}, "Specify RPC addresses of one or more Ethereum nodes")
+	fs.String(flagEthRPCs, "http://localhost:8545", "Specify comma-separated RPC addresses of one or more Ethereum nodes")
 	fs.Int64(flagEthGasPrice, 0, "The Ethereum gas price to include in the transaction; If zero, gas price will be estimated")
 	fs.Int64(flagEthGasLimit, 6000000, "The Ethereum gas limit to include in the transaction")
 	_ = fs.MarkDeprecated(flagEthRPC, fmt.Sprintf("Use the '%s' flag instead to provide one or more Ethereum RPC instances", flagEthRPCs))

--- a/cmd/peggo/grpcclient.go
+++ b/cmd/peggo/grpcclient.go
@@ -44,7 +44,8 @@ func (em *EthRPCManager) DialNext() error {
 	if em.konfig == nil {
 		return errors.New("ethRPCManager konfig is nil")
 	}
-	rpcs := em.konfig.Strings(flagEthRPCs)
+	//rpcs := em.konfig.Strings(flagEthRPCs)
+	rpcs := []string{em.konfig.String(flagEthRPC)}
 
 	em.CloseClient()
 

--- a/cmd/peggo/grpcclient.go
+++ b/cmd/peggo/grpcclient.go
@@ -16,12 +16,8 @@ var ethManager *EthRPCManager
 
 type EthRPCManager struct {
 	currentEndpoint int // the slice index of the endpoint currently used
-	//client          *ethclient.Client // the current client
-	client *rpc.Client
-	konfig *koanf.Koanf
-
-	// TODO: how to detect client failures so we can call DialNext()
-	// maybe wrap methods
+	client          *rpc.Client
+	konfig          *koanf.Koanf
 }
 
 // initializes the single instance of EthRPCManager with a given config (uses flagEthRPCs).

--- a/cmd/peggo/grpcclient.go
+++ b/cmd/peggo/grpcclient.go
@@ -1,0 +1,31 @@
+package peggo
+
+import (
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/knadh/koanf"
+	"github.com/pkg/errors"
+)
+
+// dials configured ethereum rpc endpoints, returning a client connected to the first successfully dialed
+func getEthClient(konfig *koanf.Koanf) (*ethclient.Client, error) {
+	rpcs := konfig.Strings(flagEthRPCs)
+
+	for _, endpoint := range rpcs {
+		if cli, err := ethclient.Dial(endpoint); err == nil {
+			return cli, nil
+		}
+	}
+
+	// todo #196: this doesn't try to remember if an endpoint is failing frequently
+	// which would be needed to rotate / avoid trying to dial it every single time.
+	//
+	// a cheap way to do basically that would be to store the last endpoint *successfully*
+	// dialed using a var at the top of this file, always trying that first if non-empty,
+	// clearing it on fail, and setting it to a new string whenever a dial succeeds on
+	// an endpoint in the for loop
+	//
+	// also, if there are other reasons we want to avoid an endpoint (e.g. dialing succeeds
+	// but the rpcs are behaving badly) then this function won't be able to help
+
+	return nil, errors.New("Could not connect to any of the Ethereum RPC endpoints provided")
+}

--- a/cmd/peggo/grpcclient.go
+++ b/cmd/peggo/grpcclient.go
@@ -27,5 +27,5 @@ func getEthClient(konfig *koanf.Koanf) (*ethclient.Client, error) {
 	// also, if there are other reasons we want to avoid an endpoint (e.g. dialing succeeds
 	// but the rpcs are behaving badly) then this function won't be able to help
 
-	return nil, errors.New("Could not connect to any of the Ethereum RPC endpoints provided")
+	return nil, errors.New("could not connect to any of the Ethereum RPC endpoints provided")
 }

--- a/cmd/peggo/grpcclient.go
+++ b/cmd/peggo/grpcclient.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -44,8 +45,8 @@ func (em *EthRPCManager) DialNext() error {
 	if em.konfig == nil {
 		return errors.New("ethRPCManager konfig is nil")
 	}
-	//rpcs := em.konfig.Strings(flagEthRPCs)
-	rpcs := []string{em.konfig.String(flagEthRPC)}
+
+	rpcs := strings.Split(strings.ReplaceAll(em.konfig.String(flagEthRPCs), " ", ""), ",")
 
 	em.CloseClient()
 

--- a/cmd/peggo/orchestrator.go
+++ b/cmd/peggo/orchestrator.go
@@ -120,6 +120,7 @@ func getOrchestratorCmd() *cobra.Command {
 			// than the other cmds, i.e. the client is being reused over time?
 			ethRPCEndpoint := konfig.String(flagEthRPC)
 			ethRPC, err := ethrpc.Dial(ethRPCEndpoint)
+			//ethRPC, err := ethManager.GetClient() // todo: wrong type. find out why.
 			if err != nil {
 				return fmt.Errorf("failed to dial Ethereum RPC node: %w", err)
 			}

--- a/cmd/peggo/orchestrator.go
+++ b/cmd/peggo/orchestrator.go
@@ -116,6 +116,8 @@ func getOrchestratorCmd() *cobra.Command {
 				return fmt.Errorf("failed to initialize Ethereum account: %w", err)
 			}
 
+			// todo #196: change this to try multiple endpoints. Also, is this one more complicated
+			// than the other cmds, i.e. the client is being reused over time?
 			ethRPCEndpoint := konfig.String(flagEthRPC)
 			ethRPC, err := ethrpc.Dial(ethRPCEndpoint)
 			if err != nil {

--- a/cmd/peggo/orchestrator.go
+++ b/cmd/peggo/orchestrator.go
@@ -11,7 +11,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	ethcmn "github.com/ethereum/go-ethereum/common"
-	ethrpc "github.com/ethereum/go-ethereum/rpc"
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
@@ -118,14 +117,13 @@ func getOrchestratorCmd() *cobra.Command {
 
 			// todo #196: change this to try multiple endpoints. Also, is this one more complicated
 			// than the other cmds, i.e. the client is being reused over time?
-			ethRPCEndpoint := konfig.String(flagEthRPC)
-			ethRPC, err := ethrpc.Dial(ethRPCEndpoint)
-			//ethRPC, err := ethManager.GetClient() // todo: wrong type. find out why.
+			// ethRPCEndpoint := konfig.String(flagEthRPC)
+			ethRPC, err := ethManager.GetClient()
 			if err != nil {
 				return fmt.Errorf("failed to dial Ethereum RPC node: %w", err)
 			}
 
-			fmt.Fprintf(os.Stderr, "Connected to Ethereum RPC: %s\n", ethRPCEndpoint)
+			//fmt.Fprintf(os.Stderr, "Connected to Ethereum RPC: %s\n", ethRPCEndpoint)
 			ethProvider := provider.NewEVMProvider(ethRPC)
 
 			ethGasPriceAdjustment := konfig.Float64(flagEthGasAdjustment)

--- a/cmd/peggo/orchestrator.go
+++ b/cmd/peggo/orchestrator.go
@@ -122,15 +122,11 @@ func getOrchestratorCmd() *cobra.Command {
 				return fmt.Errorf("failed to initialize Ethereum account: %w", err)
 			}
 
-			// todo #196: change this to try multiple endpoints. Also, is this one more complicated
-			// than the other cmds, i.e. the client is being reused over time?
-			// ethRPCEndpoint := konfig.String(flagEthRPC)
 			ethRPC, err := ethManager.GetClient()
 			if err != nil {
 				return fmt.Errorf("failed to dial Ethereum RPC node: %w", err)
 			}
 
-			//fmt.Fprintf(os.Stderr, "Connected to Ethereum RPC: %s\n", ethRPCEndpoint)
 			ethProvider := provider.NewEVMProvider(ethRPC)
 
 			ethGasPriceAdjustment := konfig.Float64(flagEthGasAdjustment)

--- a/cmd/peggo/peggo.go
+++ b/cmd/peggo/peggo.go
@@ -21,7 +21,7 @@ func NewRootCmd() *cobra.Command {
 		Long: `Peggo is a companion executable for orchestrating a Gravity validator.
 
 Inputs in the CLI commands can be provided via flags or environment variables. If
-using the later, prefix the environment variable with PEGGO_ and the named of the
+using the latter, prefix the environment variable with PEGGO_ and the named of the
 flag (e.g. PEGGO_COSMOS_PK).`,
 	}
 

--- a/cmd/peggo/peggo.go
+++ b/cmd/peggo/peggo.go
@@ -81,7 +81,7 @@ func parseServerConfig(cmd *cobra.Command) (*koanf.Koanf, error) {
 	konfig := koanf.New(".")
 
 	// load from file first (if provided)
-	// TODO: Support config files if/when needed.
+	// TODO: Support config files if/when needed. Koanf also supports watch the config file for changes
 	// if configPath := ctx.String(config.ConfigPath); len(configPath) != 0 {
 	// 	if err := konfig.Load(file.Provider(configPath), toml.Parser()); err != nil {
 	// 		return nil, err

--- a/test/e2e/e2e_setup_test.go
+++ b/test/e2e/e2e_setup_test.go
@@ -545,7 +545,7 @@ func (s *IntegrationTestSuite) runContractDeployment() {
 				"peggo",
 				"bridge",
 				"deploy-gravity",
-				"--eth-rpcs",
+				"--eth-rpc",
 				fmt.Sprintf("http://%s:8545", s.ethResource.Container.Name[1:]),
 				"--cosmos-grpc",
 				fmt.Sprintf("tcp://%s:9090", s.valResources[0].Container.Name[1:]),

--- a/test/e2e/e2e_setup_test.go
+++ b/test/e2e/e2e_setup_test.go
@@ -545,7 +545,7 @@ func (s *IntegrationTestSuite) runContractDeployment() {
 				"peggo",
 				"bridge",
 				"deploy-gravity",
-				"--eth-rpc",
+				"--eth-rpcs",
 				fmt.Sprintf("http://%s:8545", s.ethResource.Container.Name[1:]),
 				"--cosmos-grpc",
 				fmt.Sprintf("tcp://%s:9090", s.valResources[0].Container.Name[1:]),


### PR DESCRIPTION
Another possible way to do this:

- The one-off commands in `bridge.go` should be fine iterating their way through endpoints until they find a good one
- Possible improvement discussed in comments: remembering the last successfully dialed and always trying it first
- Still have some questions about the one in orchestrator.go, especially (if it's being reused over time) when to try to redial
