### PR TITLE
fix: Add Ethereum addresses check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+- [#217](https://github.com/umee-network/peggo/pull/217) Add validation to user input Ethereum addresses.
 - [#209](https://github.com/umee-network/peggo/pull/209) Fix the `version` command to display correctly.
 - [#205](https://github.com/umee-network/peggo/pull/205) Make sure users are warned when using unencrypted non-local urls in flags.
 

--- a/cmd/peggo/keys.go
+++ b/cmd/peggo/keys.go
@@ -271,6 +271,10 @@ func initEthereumAccountsManager(
 		ethAddressFromPk := ethcrypto.PubkeyToAddress(ethPk.PublicKey)
 
 		if len(ethKeyFrom) > 0 {
+			if !ethcmn.IsHexAddress(ethKeyFrom) {
+				return emptyEthAddress, nil, nil, fmt.Errorf("invalid eth-from address: %s", ethKeyFrom)
+			}
+
 			addr := ethcmn.HexToAddress(ethKeyFrom)
 			if addr == (ethcmn.Address{}) {
 				return emptyEthAddress, nil, nil, fmt.Errorf("failed to parse Ethereum from address: %s", ethKeyFrom)
@@ -294,6 +298,10 @@ func initEthereumAccountsManager(
 	case len(ethKeystoreDir) > 0:
 		if len(ethKeyFrom) == 0 {
 			return emptyEthAddress, nil, nil, errors.New("cannot use Ethereum keystore without from address specified")
+		}
+
+		if !ethcmn.IsHexAddress(ethKeyFrom) {
+			return emptyEthAddress, nil, nil, fmt.Errorf("invalid eth-from address: %s", ethKeyFrom)
 		}
 
 		ethKeyFromAddress = ethcmn.HexToAddress(ethKeyFrom)

--- a/cmd/peggo/orchestrator.go
+++ b/cmd/peggo/orchestrator.go
@@ -155,6 +155,9 @@ func getOrchestratorCmd() *cobra.Command {
 				konfig.Int(flagCosmosMsgsPerTx),
 			)
 
+			if !ethcmn.IsHexAddress(args[0]) {
+				return fmt.Errorf("invalid gravity address: %s", args[0])
+			}
 			gravityAddr := ethcmn.HexToAddress(args[0])
 
 			ethGravity, err := wrappers.NewGravity(gravityAddr, ethCommitter.Provider())


### PR DESCRIPTION
Add checks where there is a user-input Eth address. We are not checking any value coming from the Cosmos gRPC, it is not necessary (and would be too late to catch a malformed address)

Closes #177 