### PR TITLE
chore: fix lint warning

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,7 @@ linters:
     - misspell
     - nakedret
     - prealloc
-    - scopelint
+    - exportloopref
     - staticcheck
     - structcheck
     - stylecheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,13 @@ run:
   skip-dirs:
     - test
 
+  govet:
+    # Enable analyzers by name (in addition to default).
+    # Run `go tool vet help` to see all analyzers.
+    # Default: []
+    enable:
+      - fieldalignment
+
 linters:
   enable:
     - bodyclose
@@ -21,7 +28,6 @@ linters:
     - ineffassign
     - lll
     - misspell
-    - maligned
     - nakedret
     - prealloc
     - scopelint
@@ -53,8 +59,6 @@ linters-settings:
     max-blank-identifiers: 3
   golint:
     min-confidence: 0
-  maligned:
-    suggest-new: true
   misspell:
     locale: US
   nolintlint:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,7 @@ linters:
     - gocritic
     - gofmt
     - goimports
-    - golint
+    - revive
     - gosec
     - gosimple
     - govet
@@ -57,8 +57,11 @@ issues:
 linters-settings:
   dogsled:
     max-blank-identifiers: 3
-  golint:
-    min-confidence: 0
+  revive:
+    # Sets the default failure confidence.
+    # This means that linting errors with less than 0.8 confidence will be ignored.
+    # Default: 0.8
+    confidence: 0
   misspell:
     locale: US
   nolintlint:


### PR DESCRIPTION
- Update deprecated lint options
- Running `make lint` doesn't log warnings ;D