### PR TITLE
chore: fix backport label for v1.x.x

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -57,7 +57,7 @@ pull_request_rules:
   - name: Backport patches to release/v1.0.x branch
     conditions:
       - base=main
-      - label=S:backport/v1.0.x
+      - label=S:backport/v1.x.x
     actions:
       backport:
         branches:


### PR DESCRIPTION
We need to rename the label [S:backport/v1.0.x](https://github.com/umee-network/peggo/labels/S%3Abackport%2Fv1.0.x) to `S:backport/v1.x.x` after this is merged