### PR TITLE
feat: Add eth merge pause flag

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -57,7 +57,7 @@ pull_request_rules:
   - name: Backport patches to release/v1.0.x branch
     conditions:
       - base=main
-      - label=S:backport/v1.0.x
+      - label=S:backport/v1.x.x
     actions:
       backport:
         branches:

--- a/cmd/peggo/flags.go
+++ b/cmd/peggo/flags.go
@@ -55,6 +55,7 @@ const (
 	flagRelayerLoopMultiplier   = "relayer-loop-multiplier"
 	flagRequesterLoopMultiplier = "requester-loop-multiplier"
 	flagBridgeStartHeight       = "bridge-start-height"
+	flagEthMergePause           = "eth-merge-pause" // TODO: remove this after merge is completed
 )
 
 func cosmosFlagSet() *pflag.FlagSet {

--- a/cmd/peggo/orchestrator.go
+++ b/cmd/peggo/orchestrator.go
@@ -277,6 +277,7 @@ func getOrchestratorCmd() *cobra.Command {
 	cmd.Flags().Bool(flagRelayBatches, false, "Relay transaction batches to Ethereum")
 	cmd.Flags().Int64(flagEthBlocksPerLoop, 2000, "Number of Ethereum blocks to process per orchestrator loop")
 	cmd.Flags().String(flagCoinGeckoAPI, "https://api.coingecko.com/api/v3", "Specify the coingecko API endpoint")
+	cmd.Flags().Bool(flagEthMergePause, false, "Pause some messages related to the adaptation of the Gravity Bridge to the merge")
 
 	defaultProviders := []string{
 		umeepfprovider.ProviderOsmosis.String(),

--- a/cmd/peggo/orchestrator.go
+++ b/cmd/peggo/orchestrator.go
@@ -277,7 +277,7 @@ func getOrchestratorCmd() *cobra.Command {
 	cmd.Flags().Bool(flagRelayBatches, false, "Relay transaction batches to Ethereum")
 	cmd.Flags().Int64(flagEthBlocksPerLoop, 2000, "Number of Ethereum blocks to process per orchestrator loop")
 	cmd.Flags().String(flagCoinGeckoAPI, "https://api.coingecko.com/api/v3", "Specify the coingecko API endpoint")
-	cmd.Flags().Bool(flagEthMergePause, false, "Pause some messages related to the adaptation of the Gravity Bridge to the merge")
+	cmd.Flags().Bool(flagEthMergePause, false, "Pause some messages related to the adaptation of the Gravity Bridge to the merge") //nolint: lll
 
 	defaultProviders := []string{
 		umeepfprovider.ProviderOsmosis.String(),

--- a/cmd/peggo/orchestrator.go
+++ b/cmd/peggo/orchestrator.go
@@ -252,6 +252,7 @@ func getOrchestratorCmd() *cobra.Command {
 				konfig.Int64(flagBridgeStartHeight),
 				symbolRetriever,
 				o,
+				konfig.Bool(flagEthMergePause),
 			)
 
 			g, errCtx := errgroup.WithContext(ctx)

--- a/orchestrator/eth_event_watcher.go
+++ b/orchestrator/eth_event_watcher.go
@@ -202,6 +202,13 @@ func (p *gravityOrchestrator) CheckForEvents(
 	valsetUpdates := filterValsetUpdateEventsByNonce(valsetUpdatedEvents, lastEventResp.EventNonce)
 	deployedERC20Updates := filterERC20DeployedEventsByNonce(erc20DeployedEvents, lastEventResp.EventNonce)
 
+	// Don't send anything other than valsetUpdates
+	if p.ethMergePause {
+		deposits = []*wrappers.GravitySendToCosmosEvent{}
+		withdraws = []*wrappers.GravityTransactionBatchExecutedEvent{}
+		deployedERC20Updates = []*wrappers.GravityERC20DeployedEvent{}
+	}
+
 	if len(deposits) > 0 || len(withdraws) > 0 || len(valsetUpdates) > 0 || len(deployedERC20Updates) > 0 {
 
 		if err := p.gravityBroadcastClient.SendEthereumClaims(

--- a/orchestrator/eth_event_watcher_test.go
+++ b/orchestrator/eth_event_watcher_test.go
@@ -166,6 +166,7 @@ func TestCheckForEvents(t *testing.T) {
 			0,
 			nil,
 			nil,
+			false,
 		)
 
 		currentBlock, err := orch.CheckForEvents(context.Background(), 1, 5)
@@ -248,6 +249,7 @@ func TestCheckForEvents(t *testing.T) {
 			0,
 			nil,
 			nil,
+			false,
 		)
 
 		currentBlock, err := orch.CheckForEvents(context.Background(), 1, 5)
@@ -357,6 +359,7 @@ func TestCheckForEvents(t *testing.T) {
 			0,
 			nil,
 			nil,
+			false,
 		)
 
 		currentBlock, err := orch.CheckForEvents(context.Background(), 1, 5)
@@ -480,6 +483,7 @@ func TestCheckForEvents(t *testing.T) {
 			0,
 			nil,
 			nil,
+			false,
 		)
 
 		currentBlock, err := orch.CheckForEvents(context.Background(), 1, 5)
@@ -617,6 +621,7 @@ func TestCheckForEvents(t *testing.T) {
 			0,
 			nil,
 			nil,
+			false,
 		)
 
 		currentBlock, err := orch.CheckForEvents(context.Background(), 1, 5)

--- a/orchestrator/main_loops.go
+++ b/orchestrator/main_loops.go
@@ -272,7 +272,7 @@ func (p *gravityOrchestrator) EthSignerMainLoop(ctx context.Context) (err error)
 			}
 		}
 
-		//Try to send batch confirms. If this fails, it means there are pending batches
+		// Try to send batch confirms. If this fails, it means there are pending batches
 		// that we'll need to sign before the next upgrade.
 		var oldestUnsignedTransactionBatch []types.OutgoingTxBatch
 		if err := retry.Do(func() error {

--- a/orchestrator/main_loops.go
+++ b/orchestrator/main_loops.go
@@ -64,12 +64,14 @@ func (p *gravityOrchestrator) Start(ctx context.Context) error {
 		return p.EthOracleMainLoop(ctx)
 	})
 
-	pg.Go(func() error {
-		// looks at the BatchFees on Cosmos and uses the query endpoint BatchFees
-		// to iterate over each token to see if it is profitable, if it is
-		// it will send an request batch for that denom
-		return p.BatchRequesterLoop(ctx)
-	})
+	if !p.ethMergePause {
+		pg.Go(func() error {
+			// looks at the BatchFees on Cosmos and uses the query endpoint BatchFees
+			// to iterate over each token to see if it is profitable, if it is
+			// it will send an request batch for that denom
+			return p.BatchRequesterLoop(ctx)
+		})
+	}
 
 	pg.Go(func() error {
 		// Gets the last pending valset to send an MsgValsetConfirm that sends
@@ -81,6 +83,8 @@ func (p *gravityOrchestrator) Start(ctx context.Context) error {
 		return p.EthSignerMainLoop(ctx)
 	})
 
+	// Let this function run as is. If we see errors caused by this loop, then
+	// we might need to enable batch confirms.
 	pg.Go(func() error {
 		// Gets the latest valset available and updating it on the ethereum
 		// smartcontract if needed. Also gets all the pending transaction
@@ -268,50 +272,54 @@ func (p *gravityOrchestrator) EthSignerMainLoop(ctx context.Context) (err error)
 			}
 		}
 
-		var oldestUnsignedTransactionBatch []types.OutgoingTxBatch
-		if err := retry.Do(func() error {
-			// sign the last unsigned batch, TODO check if we already have signed this
-			txBatch, err := p.cosmosQueryClient.LastPendingBatchRequestByAddr(
-				ctx,
-				&types.QueryLastPendingBatchRequestByAddrRequest{
-					Address: p.gravityBroadcastClient.AccFromAddress().String(),
-				},
-			)
-
-			if err != nil {
-				return err
-			}
-
-			if txBatch == nil || txBatch.Batch == nil {
-				logger.Debug().Msg("no TransactionBatch waiting to be signed")
-				return nil
-			}
-
-			oldestUnsignedTransactionBatch = txBatch.Batch
-			return nil
-		}, retry.Context(ctx), retry.OnRetry(func(n uint, err error) {
-			logger.Err(err).
-				Uint("retry", n).
-				Msg("failed to get unsigned TransactionBatch for signing; retrying...")
-		})); err != nil {
-			logger.Err(err).Msg("got error, loop exits")
-			return err
-		}
-
-		for _, batch := range oldestUnsignedTransactionBatch {
-			batch := batch
-			logger.Info().
-				Uint64("batch_nonce", batch.BatchNonce).
-				Msg("sending TransactionBatch confirm for BatchNonce")
+		// Do not sent batch confirms while the Eth merge adapting period is active
+		// otherwise the message will fail causing Peggo to crash.
+		if !p.ethMergePause {
+			var oldestUnsignedTransactionBatch []types.OutgoingTxBatch
 			if err := retry.Do(func() error {
-				return p.gravityBroadcastClient.SendBatchConfirm(ctx, p.ethFrom, gravityID, batch)
+				// sign the last unsigned batch, TODO check if we already have signed this
+				txBatch, err := p.cosmosQueryClient.LastPendingBatchRequestByAddr(
+					ctx,
+					&types.QueryLastPendingBatchRequestByAddrRequest{
+						Address: p.gravityBroadcastClient.AccFromAddress().String(),
+					},
+				)
+
+				if err != nil {
+					return err
+				}
+
+				if txBatch == nil || txBatch.Batch == nil {
+					logger.Debug().Msg("no TransactionBatch waiting to be signed")
+					return nil
+				}
+
+				oldestUnsignedTransactionBatch = txBatch.Batch
+				return nil
 			}, retry.Context(ctx), retry.OnRetry(func(n uint, err error) {
 				logger.Err(err).
 					Uint("retry", n).
-					Msg("failed to sign and send TransactionBatch confirmation to Cosmos; retrying...")
+					Msg("failed to get unsigned TransactionBatch for signing; retrying...")
 			})); err != nil {
 				logger.Err(err).Msg("got error, loop exits")
 				return err
+			}
+
+			for _, batch := range oldestUnsignedTransactionBatch {
+				batch := batch
+				logger.Info().
+					Uint64("batch_nonce", batch.BatchNonce).
+					Msg("sending TransactionBatch confirm for BatchNonce")
+				if err := retry.Do(func() error {
+					return p.gravityBroadcastClient.SendBatchConfirm(ctx, p.ethFrom, gravityID, batch)
+				}, retry.Context(ctx), retry.OnRetry(func(n uint, err error) {
+					logger.Err(err).
+						Uint("retry", n).
+						Msg("failed to sign and send TransactionBatch confirmation to Cosmos; retrying...")
+				})); err != nil {
+					logger.Err(err).Msg("got error, loop exits")
+					return err
+				}
 			}
 		}
 

--- a/orchestrator/oracle_resync_test.go
+++ b/orchestrator/oracle_resync_test.go
@@ -160,6 +160,7 @@ func TestGetLastCheckedBlock(t *testing.T) {
 			0,
 			nil,
 			nil,
+			false,
 		)
 
 		block, err := orch.GetLastCheckedBlock(context.Background(), 0)

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -46,6 +46,7 @@ type gravityOrchestrator struct {
 
 	mtx             sync.Mutex
 	erc20DenomCache map[string]string
+	ethMergePause   bool
 }
 
 func NewGravityOrchestrator(
@@ -64,6 +65,7 @@ func NewGravityOrchestrator(
 	bridgeStartHeight int64,
 	symbolRetriever relayer.SymbolRetriever,
 	oracle relayer.Oracle,
+	ethMergePause bool, // TODO: remove this after merge is completed
 	options ...func(GravityOrchestrator),
 ) GravityOrchestrator {
 
@@ -84,6 +86,7 @@ func NewGravityOrchestrator(
 		bridgeStartHeight:          uint64(bridgeStartHeight),
 		symbolRetriever:            symbolRetriever,
 		oracle:                     oracle,
+		ethMergePause:              ethMergePause,
 	}
 
 	for _, option := range options {


### PR DESCRIPTION
Add `--eth-merge-pause="true"` to pause some messages from being sent during the pause period of the bridge.

Things paused:
- SendToCosmos
- SendToEth
- DeployedERC20
- Batch requests

Confirms are all enabled. If we see any batch confirms, it means we'll need to add an extra upgrade step.