### PR TITLE
fix: add ca-certificates in final image

### DIFF
--- a/contrib/images/Dockerfile
+++ b/contrib/images/Dockerfile
@@ -8,6 +8,7 @@ RUN make install &&  \
 
 # prepare final image
 FROM ubuntu:rolling
+RUN apt-get update -y && apt-get install ca-certificates -y
 COPY --from=builder /go/bin/peggo /usr/local/bin/
 COPY --from=builder /src/peggo/libwasmvm.x86_64.so /lib/
 CMD ["peggo"]


### PR DESCRIPTION
Otherwise you'd get:
```
3:15AM DBG connecting to websocket module=oracle provider=okx
3:15AM DBG connecting to websocket module=oracle provider=coinbase
3:15AM DBG connecting to websocket module=oracle provider=huobi
3:15AM DBG connecting to websocket module=oracle provider=mexc
3:15AM DBG connecting to websocket module=oracle provider=bitget
3:15AM ERR error="error connecting to bitget websocket: x509: certificate signed by unknown authority" module=oracle provider=bitget
3:15AM DBG connecting to websocket module=oracle provider=bitget
3:15AM ERR error="error connecting to coinbase websocket: x509: certificate signed by unknown authority" module=oracle provider=coinbase
3:15AM DBG connecting to websocket module=oracle provider=coinbase
3:15AM ERR error="error connecting to okx websocket: x509: certificate signed by unknown authority" module=oracle provider=okx
3:15AM DBG connecting to websocket module=oracle provider=okx
3:15AM DBG Error getting available pairs for provider error="Get \"https://api-osmosis.imperator.co/pairs/v1/summary\": x509: certificate signed by unknown authority" module=oracle provider_name=osmosis
3:15AM ERR error="error connecting to mexc websocket: x509: certificate signed by unknown authority" module=oracle provider=mexc
3:15AM DBG connecting to websocket module=oracle provider=mexc
3:15AM ERR error="error connecting to bitget websocket: x509: certificate signed by unknown authority" module=oracle provider=bitget
3:15AM ERR error="error connecting to coinbase websocket: x509: certificate signed by unknown authority" module=oracle provider=coinbase
3:15AM ERR error="error connecting to okx websocket: x509: certificate signed by unknown authority" module=oracle provider=okx
3:15AM DBG Error getting available pairs for provider error="Get \"https://api.huobi.pro/market/tickers\": x509: certificate signed by unknown authority" module=oracle provider_name=huobi
3:15AM ERR error="error connecting to mexc websocket: x509: certificate signed by unknown authority" module=oracle provider=mexc
3:15AM ERR error="error connecting to huobi websocket: x509: certificate signed by unknown authority" module=oracle provider=huobi
3:15AM DBG connecting to websocket module=oracle provider=huobi
3:15AM INF batch relay enabled; starting to relay batches to Ethereum loop=RelayerMainLoop module=gravity_relayer
3:15AM FTL failed to connect to Alchemy websocket endpoint=wss://eth-mainnet.g.alchemy.com/v2/xxxxxxx err="x509: certificate signed by unknown authority" module=gravity_contract
```